### PR TITLE
fixed bus error after wakeup

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -334,13 +334,13 @@ PWRM_CALLBACK(Wakeup)
     DBG_vPrintf(TRUE, "\nWaking...\n");
     DBG_vUartFlush();
 
+    // Restore Mac settings (turns radio on)
+    vMAC_RestoreSettings();
+
     // Re-initialize hardware and interrupts
     TARGET_INITIALISE();
     SET_IPL(0);
     portENABLE_INTERRUPTS();
-
-    // Restore Mac settings (turns radio on)
-    vMAC_RestoreSettings();
 
     // Wake the timers
     ZTIMER_vWake();


### PR DESCRIPTION
when is pending timer that needs radio, exception 'Bus error' is raised. IMHO it's because during wakeup radio is enabled after timers