### PR TITLE
Enable on-board AT2401C RF front-end (PA/LNA) for full TX range, plus join/leave split, off-network fallback and fixes

### DIFF
--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+  workflow_dispatch:
 
 env:
   TARGET: HelloZigbee.ota

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Compute build number
+        id: bn
+        run: echo "num=$((${{ github.run_number }} + 95))" >> "$GITHUB_OUTPUT"
       - name: Get toolchain
         run: |
           mkdir -p ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }} && \
@@ -34,7 +37,7 @@ jobs:
       - name: Configure CMake
         id: configure
         run: |
-          cmake -B ${{github.workspace}}/build -DTOOLCHAIN_PREFIX=$(realpath ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }}/ba-toolchain) -DBUILD_NUMBER=${{github.run_number}} -DBOARD=${{matrix.board}}
+          cmake -B ${{github.workspace}}/build -DTOOLCHAIN_PREFIX=$(realpath ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }}/ba-toolchain) -DBUILD_NUMBER=${{ steps.bn.outputs.num }} -DBOARD=${{matrix.board}}
       - name: Build
         id: build
         run: |
@@ -43,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Artifact name
-          name: hello_zigbee_${{matrix.board}}_${{github.run_number}}
+          name: hello_zigbee_${{matrix.board}}_${{ steps.bn.outputs.num }}
           # A file, directory or wildcard pattern that describes what to upload
           path: |
             ${{github.workspace}}/${{ env.ARTIFACT_DIR }}/*.bin

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -15,13 +15,6 @@ jobs:
     strategy:
       matrix:
         board: ["EBYTE_E75", "QBKG11LM", "QBKG12LM"]
-        # Same firmware binary, two OTA-header manufacturer codes (MANUFACTURER_ID only affects the
-        # .ota header, not the .bin). z2m matches an OTA image to a device by manufacturer code:
-        #  - 0x115F (Lumi): image to CONVERT a stock Aqara device to hellozigbee (matches stock fw)
-        #  - 0x1037 (NXP):  image to UPDATE an already-flashed hellozigbee device (matches ZCL_MANUFACTURER_CODE)
-        manufacturer:
-          - {id: "0x115F", label: "aqara-convert"}
-          - {id: "0x1037", label: "hellozigbee-update"}
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
@@ -44,7 +37,7 @@ jobs:
       - name: Configure CMake
         id: configure
         run: |
-          cmake -B ${{github.workspace}}/build -DTOOLCHAIN_PREFIX=$(realpath ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }}/ba-toolchain) -DBUILD_NUMBER=${{ steps.bn.outputs.num }} -DBOARD=${{matrix.board}} -DMANUFACTURER_ID=${{ matrix.manufacturer.id }}
+          cmake -B ${{github.workspace}}/build -DTOOLCHAIN_PREFIX=$(realpath ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }}/ba-toolchain) -DBUILD_NUMBER=${{ steps.bn.outputs.num }} -DBOARD=${{matrix.board}}
       - name: Build
         id: build
         run: |
@@ -53,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Artifact name
-          name: hello_zigbee_${{matrix.board}}_${{ matrix.manufacturer.label }}_${{ steps.bn.outputs.num }}
+          name: hello_zigbee_${{matrix.board}}_${{ steps.bn.outputs.num }}
           # A file, directory or wildcard pattern that describes what to upload
           path: |
             ${{github.workspace}}/${{ env.ARTIFACT_DIR }}/*.bin

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -3,7 +3,6 @@ name: Build
 on:
   workflow_dispatch:
   push:
-  workflow_dispatch:
 
 env:
   TARGET: HelloZigbee.ota

--- a/.github/workflows/c_cpp.yml
+++ b/.github/workflows/c_cpp.yml
@@ -15,6 +15,13 @@ jobs:
     strategy:
       matrix:
         board: ["EBYTE_E75", "QBKG11LM", "QBKG12LM"]
+        # Same firmware binary, two OTA-header manufacturer codes (MANUFACTURER_ID only affects the
+        # .ota header, not the .bin). z2m matches an OTA image to a device by manufacturer code:
+        #  - 0x115F (Lumi): image to CONVERT a stock Aqara device to hellozigbee (matches stock fw)
+        #  - 0x1037 (NXP):  image to UPDATE an already-flashed hellozigbee device (matches ZCL_MANUFACTURER_CODE)
+        manufacturer:
+          - {id: "0x115F", label: "aqara-convert"}
+          - {id: "0x1037", label: "hellozigbee-update"}
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
@@ -37,7 +44,7 @@ jobs:
       - name: Configure CMake
         id: configure
         run: |
-          cmake -B ${{github.workspace}}/build -DTOOLCHAIN_PREFIX=$(realpath ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }}/ba-toolchain) -DBUILD_NUMBER=${{ steps.bn.outputs.num }} -DBOARD=${{matrix.board}}
+          cmake -B ${{github.workspace}}/build -DTOOLCHAIN_PREFIX=$(realpath ${{github.workspace}}/${{ env.TOOLCHAIN_DIR }}/ba-toolchain) -DBUILD_NUMBER=${{ steps.bn.outputs.num }} -DBOARD=${{matrix.board}} -DMANUFACTURER_ID=${{ matrix.manufacturer.id }}
       - name: Build
         id: build
         run: |
@@ -46,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Artifact name
-          name: hello_zigbee_${{matrix.board}}_${{ steps.bn.outputs.num }}
+          name: hello_zigbee_${{matrix.board}}_${{ matrix.manufacturer.label }}_${{ steps.bn.outputs.num }}
           # A file, directory or wildcard pattern that describes what to upload
           path: |
             ${{github.workspace}}/${{ env.ARTIFACT_DIR }}/*.bin

--- a/Readme.md
+++ b/Readme.md
@@ -206,7 +206,7 @@ The device implements a common type of home automation devices. On the first sta
 
 Once the device joined the network, zigbee2mqtt will start intervieweing the device, which will take up to 15 seconds. If the zigbee2mqtt external converter is installed, the z2m system will provide full access to the device features.
 
-Device automatically tries to rejoin the network if network conditions change (e.g. parent/neighbour router no longer responds). Device joining and rejoining, as well as failure recovery is implemented using BDB component (a part of Zigbee SDK). The device performs several rejoin attempts before giving up. Pressing both device buttons for 5 seconds will force device to leave the network.
+Device automatically tries to rejoin the network if network conditions change (e.g. parent/neighbour router no longer responds). Device joining and rejoining, as well as failure recovery is implemented using BDB component (a part of Zigbee SDK). The device performs several rejoin attempts before giving up. Pressing and holding both device buttons for 30 seconds will force the device to leave the network (a deliberately longer hold than the 5 seconds used for joining, so that a normal long press - e.g. hold-to-dim - cannot accidentally trigger a leave). The device can also be removed from the coordinator side (e.g. via the Zigbee2MQTT "Remove device" function).
 
 ## Main functionality
 

--- a/doc/AT2401C_rf_frontend_RE.md
+++ b/doc/AT2401C_rf_frontend_RE.md
@@ -1,0 +1,196 @@
+# QBKG11LM / QBKG12LM — AT2401C RF front-end (PA/LNA) reverse-engineering
+
+Reverse-engineering of the **2.4 GHz RF front-end module (FEM)** on the Aqara
+**QBKG11LM / QBKG12LM** with-neutral wall switches (board `LM15-LNS-PA-A-T0`, NXP
+**JN5169** MCU), and the one-line firmware change that enables it in the
+**hellozigbee** firmware.
+
+doc part26 spotted an "antenna amplifier" on this board but did not reverse-engineer
+it. This document fills that gap: the chip, its wiring to the JN5169, how to switch it
+on, and the measured effect.
+
+## Summary — the problem this solves
+
+On stock hellozigbee the switch **transmits far weaker than the original Aqara firmware**:
+neighbouring routers hear it poorly (the coordinator often can't hear it directly at all),
+while the device itself hears everyone fine. That good-RX / deaf-TX **asymmetry** is the
+tell-tale of a transmit-path power deficit, and it survived every *core-radio* power tweak
+(`eAppApiPlmeSet` max PHY power, `vAppApiSetComplianceLimits`) — because the deficit isn't in
+the core radio.
+
+**Root cause:** the board carries an external **AT2401C** front-end module (PA + LNA + T/R
+switch — the "PA" in `LM15-LNS-`**`PA`**`-A-T0`). Its power amplifier only engages when its
+`TXEN` pin is driven high. hellozigbee never drives it, so the device transmits on the **bare
+JN5169 radio (~0 dBm)**, whereas stock Aqara firmware drives the module's **+22 dBm PA**.
+
+**Fix:** one call at radio init — `vAHI_HighPowerModuleEnable(TRUE, TRUE)` — which makes the
+radio auto-drive its RFTX/RFRX control outputs (DIO3/DIO2), wired to the module's TXEN/RXEN.
+
+---
+
+## 1. The chip — AT2401C
+
+- 2.4 GHz FEM: **PA + LNA + T/R switch**, QFN-16 (3×3 mm), VDD **2.0–3.6 V**, **+22 dBm**
+  saturated output, ~90 mA at +20 dBm TX. (Skyworks **RFX2401C** is a pin/function twin.)
+- Sample marking: `2401C  4447.1  UH1826` (`2401C` = part; the rest is lot/date).
+
+### Pinout (top view, pin-1 dot at top-left, counter-clockwise)
+
+```
+                     T O P   edge  (read L→R: 16,15,14,13)
+                    16     15     14     13
+                    VDD    GND    VDD    DNC
+              ●      │      │      │      │
+             ┌───────┴──────┴──────┴──────┴───────┐
+    1  GND ──┤                                    ├── 12  GND
+    2  GND ──┤                                    ├── 11  GND
+    3  GND ──┤             AT2401C                ├── 10  ANT
+             │            (TOP VIEW)              │
+    4  TXRX ─┤        EP (centre pad) = GND       ├──  9  GND
+             └───────┬──────┬──────┬──────┬───────┘
+                     │      │      │      │
+                     5      6      7      8
+                    TXEN   RXEN   GND    GND
+                     B O T T O M  edge  (read L→R: 5,6,7,8)
+```
+
+| Pin | Name | Function |
+|---|---|---|
+| 4 | **TXRX** | RF signal to/from the transceiver (JN5169 side); DC-shorted to GND |
+| 5 | **TXEN** | TX enable — CMOS control input |
+| 6 | **RXEN** | RX enable — CMOS control input |
+| 10 | **ANT** | PA output / LNA input (antenna side); DC-shorted to GND |
+| 16 | **VDD** | supply input (pin 14 is a second VDD, internally tied to 16) |
+| 13 | DNC | do not connect |
+| 1,2,3,7,8,9,11,12,15 + EP | GND | ground |
+
+### Control logic
+
+| TXEN | RXEN | State |
+|---|---|---|
+| 1 | X | **TX path active (PA on)** |
+| 0 | 1 | RX path active (LNA on) |
+| 0 | 0 | shutdown / sleep |
+
+Both controls are **active-high** (logic "1" ≥ 1.2 V). T/R and shutdown switching ~800 ns.
+
+---
+
+## 2. Reverse-engineered wiring — AT2401C ↔ JN5169
+
+Traced by continuity on a dead board. The two control lines each run through a **1 kΩ series
+resistor** (the datasheet's recommended control-drive) to the JN5169's dedicated radio-control
+outputs; the RF port and supply route as expected.
+
+```
+   AT2401C                                   JN5169 (QFN40)
+   ┌──────────────┐
+   │ 5  TXEN ───────[ 1kΩ ]──────────────► 19  DIO3 / RFTX    (radio TX-enable output)
+   │ 6  RXEN ───────[ 1kΩ ]──────────────► 18  DIO2 / RFRX    (radio RX-enable output)
+   │ 4  TXRX ───────[ match net ]────────► 13  RF_IO          (single-ended 50 Ω)
+   │ 10 ANT  ────────────────────────────► PCB antenna
+   │ 16 VDD  ────────────────────────────► 30  VDDD           (3.3 V digital supply rail)
+   └──────────────┘
+```
+
+| AT2401C | via | JN5169 pin | JN5169 function |
+|---|---|---|---|
+| TXEN (5) | 1 kΩ | **19** | **DIO3 / RFTX** — radio transmitter control output |
+| RXEN (6) | 1 kΩ | **18** | **DIO2 / RFRX** — radio receiver control output |
+| TXRX (4) | RF match | **13** | **RF_IO** — RF antenna port |
+| ANT (10) | — | — | PCB antenna |
+| VDD (16) | — | **30** | **VDDD** — digital supply input (the 2.2–3.6 V rail, ~3.3 V) |
+
+Notes:
+- `VDDD` (pin 30) is the JN5169's **supply input**, not one of the internal ~1.8 V regulator
+  (`VB_*`) pins — so the FEM is fed from the same rail as the MCU, within its 2.0–3.6 V window.
+- The `TXRX ↔ RF_IO` link is through the RF matching network (series DC-block + π-match), so it
+  is not a DC short — trace it along the RF track, not with a continuity beep.
+
+---
+
+## 3. How the JN5169 drives it
+
+`DIO2/RFRX` (pin 18) and `DIO3/RFTX` (pin 19) are the JN516x radio's **dedicated RX/TX control
+outputs**. When high-power-module control is enabled, the MAC/PHY **asserts them automatically**:
+RFTX high during transmit, RFRX high during receive. Their **active-high** polarity matches the
+AT2401C's TXEN/RXEN directly (no inverter needed), so:
+
+- **transmit** → RFTX high → TXEN high → **PA engaged**
+- **receive**  → RFRX high → RXEN high → **LNA engaged**
+
+Per part26's DIO inventory, DIO2/DIO3 are otherwise unused (relay/buttons/LEDs live elsewhere),
+so nothing else contends for them.
+
+---
+
+## 4. The firmware enable
+
+In `ZigbeeDevice::ZigbeeDevice()`, **before** `ZPS_eAplAfInit()` brings up the MAC/PHY:
+
+```c
+// AppHardwareApi.h
+vAHI_HighPowerModuleEnable(TRUE, TRUE);   // TX and RX control must be enabled together
+```
+
+- Requires `#include "AppHardwareApi.h"`.
+- This is a **one-time init** — it configures the radio to auto-toggle DIO2/DIO3 in hardware on
+  every RX/TX; it does not need re-applying per packet. (If a stack radio re-init on rejoin ever
+  dropped it, re-assert it in the rejoin path — but a non-sleeping mains router holds it.)
+- Keep the existing `vAppApiSetComplianceLimits(...)` ETSI ceiling; with a real PA in circuit it
+  finally does something useful (it bounds the amplified output).
+
+**Channel-26 caveat:** NXP documents that `vAHI_HighPowerModuleEnable` **breaches emission limits
+on channel 26** at full PA (band-edge spectral mask). If the network runs on channel 26, use
+`vAppApiSetHighPowerMode()` (802.15.4 stack API) instead, which reduces power there. Off channel
+26 this does not apply.
+
+### What did NOT work (and why)
+
+- `eAppApiPlmeSet(PHY_PIB_ATTR_TX_POWER, 10)` — no measurable effect (ineffective in the ZPS
+  runtime context, and irrelevant while the external PA is off).
+- `vAppApiSetComplianceLimits(...)` alone — no effect: it's a *ceiling* the bare core already sits
+  below, and the missing gain was the un-powered PA, not the core level.
+
+The transmit deficit was the external PA the whole time, not the JN5169's own output power.
+
+---
+
+## 5. Validation (measured)
+
+Zigbee networkmap **inbound LQI** (how neighbouring routers hear the device). Same switch model,
+**same wall socket**, three firmware states. Neighbour names anonymised (R1…R8 + Coordinator).
+
+| neighbour hears it | PA off (before) | **PA on (this fix)** | **stock Aqara FW** |
+|---|---|---|---|
+| Coordinator (direct) | — (unreachable) | 104 | 103 |
+| R1 | 58 | 186 | 185 |
+| R2 | 38 | 177 | 175 |
+| R3 | 0 | 147 | 152 |
+| R4 | 0 | 126 | 123 |
+| R5 | — | 100 | 88 |
+| R6 | — | 85 | 86 |
+| R7 | — | 85 | 80 |
+| R8 | — | 75 | 63 |
+| **median / max** | **0 / 58** | **104 / 186** | **103 / 185** |
+
+- **PA off:** the device was effectively invisible to the coordinator (routed via a neighbour),
+  heard by only a couple of routers, the rest at LQI 0.
+- **PA on:** the coordinator hears it **directly**, all routers hear it strongly, and the RX/TX
+  asymmetry disappears (it hears its strongest neighbour at ~194, that neighbour now hears it at
+  ~186 — reciprocal).
+- **Versus stock Aqara firmware in the identical socket:** matched to within a couple of LQI
+  points on **every** link. The fix reproduces the factory operating point exactly — it enables
+  the PA the same way stock does, **without over-driving** (nothing is pushed to LQI 255; peaks
+  sit at/under the stock device's).
+
+---
+
+## References
+
+- **AT2401C** datasheet — Hangzhou Zhongkewei (DS-AT2401C).
+- **RFX2401C** datasheet — Skyworks (pin/function twin).
+- **JN5169** datasheet (NXP) — pin table: DIO2/RFRX pin 18, DIO3/RFTX pin 19, RF_IO pin 13,
+  VDDD pin 30.
+- NXP **JN-UG-3087** (JN516x Integrated Peripherals API) — `vAHI_HighPowerModuleEnable`.
+- hellozigbee doc **part26** — identifies the FEM ("antenna amplifier").

--- a/src/ButtonHandler.cpp
+++ b/src/ButtonHandler.cpp
@@ -47,13 +47,13 @@ const char * ButtonHandler::getStateName(ButtonState state)
     return "";
 }
 
-void ButtonHandler::setConfiguration(SwitchMode sMode, RelayMode rMode, uint16 maxPause, uint16 minLongPress)
+void ButtonHandler::setConfiguration(SwitchMode sMode, RelayMode rMode, uint16 maxPauseMs, uint16 minLongPress)
 {
     // This function does the same as 4 functions below all together, but as a single transaction.
     // This is needed to avoid cluttering log with multiple changeState messages
     switchMode = sMode;
     relayMode = rMode;
-    maxPause = maxPause/ButtonPollCycle;
+    maxPause = maxPauseMs/ButtonPollCycle;
     longPressDuration = minLongPress/ButtonPollCycle;
 
     changeState(INVALID, true);

--- a/src/ButtonsTask.cpp
+++ b/src/ButtonsTask.cpp
@@ -101,18 +101,32 @@ void ButtonsTask::timerCallback()
         longPressCounter = 0;
     }
 
-    // Process a very long press of all buttons to join/leave the network
-    // TODO: Perhaps just a long press is not a good key combination for join/rejoin. For example buttons may be accidentally
-    // pressed by to a heavy object. It may be reasonable to introduce some patter, e.g. press both button 2 times, and then hold.
-    if(longPressCounter > 5000/ButtonPollCycle && allButtonsPressed)
+    // Process a very long press of all buttons to join/leave the network.
+    // Join and leave use asymmetric thresholds so that an everyday long press (e.g. a
+    // hold-to-dim gesture routed through the button) can never accidentally leave the network:
+    //   - JOIN : all buttons held ~5s while NOT on a network (a fresh device is not running
+    //            any hold gesture, so a short threshold is safe and convenient).
+    //   - LEAVE: all buttons held ~30s while joined - deliberately long. Prefer removing the
+    //            device from the coordinator (e.g. Zigbee2MQTT "Remove device") over this
+    //            local escape hatch, which mainly exists for an orphaned device.
+    if(allButtonsPressed)
     {
-        for(uint8 h = 0; h < numHandlers; h++)
-            handlers[h].handler->resetButtonStateMachine();
+        ZigbeeDevice * zigbeeDevice = ZigbeeDevice::getInstance();
+        bool doJoin  = !zigbeeDevice->isJoined() && longPressCounter > 5000/ButtonPollCycle;
+        bool doLeave =  zigbeeDevice->isJoined() && longPressCounter > 30000/ButtonPollCycle;
 
-        longPressCounter = 0;
+        if(doJoin || doLeave)
+        {
+            for(uint8 h = 0; h < numHandlers; h++)
+                handlers[h].handler->resetButtonStateMachine();
 
-        // Perform the join/leave
-        ZigbeeDevice::getInstance()->joinOrLeaveNetwork();
+            longPressCounter = 0;
+
+            if(doJoin)
+                zigbeeDevice->joinNetwork();
+            else
+                zigbeeDevice->leaveNetwork();
+        }
     }
 }
 

--- a/src/ButtonsTask.cpp
+++ b/src/ButtonsTask.cpp
@@ -10,6 +10,7 @@ ButtonsTask::ButtonsTask()
 {
     idleCounter = 0;
     longPressCounter = 0;
+    gestureFired = false;
 
     buttonsMask = 0;
     buttonsOverride = 0;
@@ -91,14 +92,19 @@ void ButtonsTask::timerCallback()
 
     // Reset the idle counter when user interacts with a button
     if(someButtonPressed)
-    {
         idleCounter = 0;
+    else
+        idleCounter++;
+
+    // Count how long ALL buttons are held together (the join/leave gesture). Counting any-button
+    // presses instead would let a long single-button hold (e.g. hold-to-dim on a 2-gang device)
+    // pre-charge the counter, so that merely touching the second button would fire the gesture.
+    if(allButtonsPressed)
         longPressCounter++;
-    }
     else
     {
-        idleCounter++;
         longPressCounter = 0;
+        gestureFired = false;   // Buttons released - re-arm the gesture
     }
 
     // Process a very long press of all buttons to join/leave the network.
@@ -109,7 +115,10 @@ void ButtonsTask::timerCallback()
     //   - LEAVE: all buttons held ~30s while joined - deliberately long. Prefer removing the
     //            device from the coordinator (e.g. Zigbee2MQTT "Remove device") over this
     //            local escape hatch, which mainly exists for an orphaned device.
-    if(allButtonsPressed)
+    // At most one gesture fires per continuous press (gestureFired latch): without it a stuck
+    // button would leave at 30s, rejoin 5s later, leave again, and so on - endlessly flapping
+    // on the network and wearing PDM flash with connectionState writes on every transition.
+    if(allButtonsPressed && !gestureFired)
     {
         ZigbeeDevice * zigbeeDevice = ZigbeeDevice::getInstance();
         bool doJoin  = !zigbeeDevice->isJoined() && longPressCounter > 5000/ButtonPollCycle;
@@ -120,7 +129,7 @@ void ButtonsTask::timerCallback()
             for(uint8 h = 0; h < numHandlers; h++)
                 handlers[h].handler->resetButtonStateMachine();
 
-            longPressCounter = 0;
+            gestureFired = true;
 
             if(doJoin)
                 zigbeeDevice->joinNetwork();

--- a/src/ButtonsTask.cpp
+++ b/src/ButtonsTask.cpp
@@ -49,7 +49,7 @@ bool ButtonsTask::handleDioInterrupt(uint32 dioStatus)
 
 bool ButtonsTask::canSleep() const
 {
-    return idleCounter > 5000 / ButtonPollCycle; // 500 cycles * 10 ms = 5 sec
+    return idleCounter > 5000 / ButtonPollCycle; // 250 cycles * 20 ms = 5 sec
 }
 
 void ButtonsTask::registerHandler(uint32 pinMask, IButtonHandler * handler)

--- a/src/ButtonsTask.h
+++ b/src/ButtonsTask.h
@@ -22,6 +22,7 @@ class ButtonsTask : public PeriodicTask
 {
     uint32 idleCounter;
     uint32 longPressCounter;
+    bool gestureFired;
 
     HandlerRecord handlers[ZCL_NUMBER_OF_ENDPOINTS+1];
     uint8 numHandlers;

--- a/src/EndpointManager.cpp
+++ b/src/EndpointManager.cpp
@@ -101,5 +101,5 @@ void EndpointManager::handleDeviceJoin()
 void EndpointManager::handleDeviceLeave()
 {
     for(uint8 ep = 1; ep <= ZCL_NUMBER_OF_ENDPOINTS; ep++)
-        registry[ep]->handleDeviceJoin();
+        registry[ep]->handleDeviceLeave();
 }

--- a/src/OOSC.c
+++ b/src/OOSC.c
@@ -76,7 +76,7 @@ PUBLIC  teZCL_Status eCLD_OOSCCreateOnOffSwitchConfig(
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->iMinLongPress = 1000;
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eLongPressMode = E_CLD_OOSC_LONG_PRESS_MODE_NONE;
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eOperationMode = E_CLD_OOSC_OPERATION_MODE_SERVER;
-            ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eOperationMode = E_CLD_OOSC_INTERLOCK_MODE_NONE;
+            ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eInterlockMode = E_CLD_OOSC_INTERLOCK_MODE_NONE;
 #endif
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->u16ClusterRevision = CLD_OOSC_CLUSTER_REVISION;
         }

--- a/src/SwitchEndpoint.cpp
+++ b/src/SwitchEndpoint.cpp
@@ -162,15 +162,12 @@ void SwitchEndpoint::restoreButtonsConfiguration()
                             sizeof(sOnOffConfigServerCluster),
                             &readBytes);
 
-    // Configure buttons state machine with read values
-    buttonHandler.setConfiguration((SwitchMode)sOnOffConfigServerCluster.eSwitchMode, 
-                                   (RelayMode)sOnOffConfigServerCluster.eRelayMode,
-                                   sOnOffConfigServerCluster.iMaxPause,
-                                   sOnOffConfigServerCluster.iMinLongPress);
-
     // Make sure that client only endpoints have client mode set
     if(clientOnly)
         sOnOffConfigServerCluster.eOperationMode = E_CLD_OOSC_OPERATION_MODE_CLIENT;
+
+    // Configure the buttons state machine, applying the off-network coupling fallback if needed
+    applyButtonsConfiguration();
 
     // Dump the restored configuration
     DBG_vPrintf(TRUE, "SwitchEndpoint EP=%d: Restored buttons configuration:\n", getEndpointId());
@@ -187,6 +184,25 @@ void SwitchEndpoint::saveButtonsConfiguration()
     PDM_eSaveRecordData(getPdmIdForEndpoint(getEndpointId(), PARAM_ID_BUTTON_CONFIG),
                         &sOnOffConfigServerCluster,
                         sizeof(sOnOffConfigServerCluster));
+}
+
+void SwitchEndpoint::applyButtonsConfiguration()
+{
+    // While the device is off the network it cannot be controlled over Zigbee, so a decoupled
+    // (RELAY_MODE_UNLINKED) configuration would leave the relay stuck and uncontrollable. In that
+    // case fall back to a coupled RELAY_MODE_FRONT so the physical button keeps working like a
+    // plain switch. The persisted configuration in PDM (and the in-memory attribute values) are
+    // left untouched, so the original (e.g. decoupled) behaviour is restored automatically once
+    // the device rejoins. The matching server-mode fallback lives in runsInServerMode().
+    bool offlineDumbSwitch = !clientOnly && !ZigbeeDevice::getInstance()->isJoined();
+    RelayMode relayMode = offlineDumbSwitch
+                            ? RELAY_MODE_FRONT
+                            : (RelayMode)sOnOffConfigServerCluster.eRelayMode;
+
+    buttonHandler.setConfiguration((SwitchMode)sOnOffConfigServerCluster.eSwitchMode,
+                                   relayMode,
+                                   sOnOffConfigServerCluster.iMaxPause,
+                                   sOnOffConfigServerCluster.iMinLongPress);
 }
 
 void SwitchEndpoint::init()
@@ -664,6 +680,12 @@ bool SwitchEndpoint::runsInServerMode() const
     if(clientOnly)
         return false;
 
+    // Off the network the endpoint always acts as a local server, so the relay stays controllable
+    // by the physical button (paired with the coupling fallback in applyButtonsConfiguration()).
+    // The persisted operation mode is honoured again once the device is back on the network.
+    if(!ZigbeeDevice::getInstance()->isJoined())
+        return true;
+
     bool serverMode = (sOnOffConfigServerCluster.eOperationMode == E_CLD_OOSC_OPERATION_MODE_SERVER);
     DBG_vPrintf(TRUE, "SwitchEndpoint EP=%d: ServerMode=%d (mode=%d)\n", getEndpointId(), serverMode, sOnOffConfigServerCluster.eOperationMode);
     return serverMode;
@@ -671,12 +693,18 @@ bool SwitchEndpoint::runsInServerMode() const
 
 void SwitchEndpoint::handleDeviceJoin()
 {
+    // Back on the network: restore the configured (possibly decoupled) button behaviour
+    applyButtonsConfiguration();
+
     // Force resetting the LED
     doStateChange(getState());
 }
 
 void SwitchEndpoint::handleDeviceLeave()
 {
+    // Off the network: fall back to a coupled local switch so the relay stays usable
+    applyButtonsConfiguration();
+
     // Force resetting the LED
     doStateChange(getState());
 }

--- a/src/SwitchEndpoint.cpp
+++ b/src/SwitchEndpoint.cpp
@@ -642,15 +642,55 @@ teZCL_CommandStatus SwitchEndpoint::handleCheckAttributeRange(tsZCL_CallBackEven
     uint16 attribute = psEvent->uMessage.sIndividualAttributeResponse.u16AttributeEnum;
     uint16 cluster = psEvent->psClusterInstance->psClusterDefinition->u16ClusterEnum;
 
-    // Prevent switching client only endpoint to a server mode
-    if(cluster == GENERAL_CLUSTER_ID_ONOFF_SWITCH_CONFIGURATION && attribute == E_CLD_OOSC_ATTR_ID_SWITCH_OPERATION_MODE)
+    // Validate values written to the OOSC enum attributes. The ZCL layer only checks the type
+    // width (enum8), not the value, and an out-of-range value would be persisted in PDM (thus
+    // surviving reboots) while the button handlers treat unknown values as a no-op - i.e. a
+    // single bad write could disable the physical button until a valid value is rewritten.
+    if(cluster == GENERAL_CLUSTER_ID_ONOFF_SWITCH_CONFIGURATION)
     {
         uint8 value = *(uint8*)psEvent->uMessage.sIndividualAttributeResponse.pvAttributeData;
-        if(clientOnly && value != E_CLD_OOSC_OPERATION_MODE_CLIENT)
-            return E_ZCL_CMDS_INVALID_VALUE;
+
+        switch(attribute)
+        {
+            case E_CLD_OOSC_ATTR_ID_SWITCH_OPERATION_MODE:
+                // Also prevent switching client only endpoint to a server mode
+                if(clientOnly && value != E_CLD_OOSC_OPERATION_MODE_CLIENT)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                if(value > E_CLD_OOSC_OPERATION_MODE_CLIENT)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_MODE:
+                if(value > SWITCH_MODE_MULTIFUNCTION)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_ACTIONS:
+                if(value > E_CLD_OOSC_ACTION_TOGGLE)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_RELAY_MODE:
+                if(value > RELAY_MODE_LONG)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_LONG_PRESS_MODE:
+                if(value > E_CLD_OOSC_LONG_PRESS_MODE_LEVEL_CTRL_DOWN)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_INTERLOCK_MODE:
+                if(value > E_CLD_OOSC_INTERLOCK_MODE_OPPOSITE)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            default:
+                break;
+        }
     }
 
-    // By default we do not perform attribute value validation
+    // Other attributes are not range-validated
     return E_ZCL_CMDS_SUCCESS;
 }
 

--- a/src/SwitchEndpoint.cpp
+++ b/src/SwitchEndpoint.cpp
@@ -189,17 +189,20 @@ void SwitchEndpoint::saveButtonsConfiguration()
 void SwitchEndpoint::applyButtonsConfiguration()
 {
     // While the device is off the network it cannot be controlled over Zigbee, so a decoupled
-    // (RELAY_MODE_UNLINKED) configuration would leave the relay stuck and uncontrollable. In that
-    // case fall back to a coupled RELAY_MODE_FRONT so the physical button keeps working like a
-    // plain switch. The persisted configuration in PDM (and the in-memory attribute values) are
-    // left untouched, so the original (e.g. decoupled) behaviour is restored automatically once
-    // the device rejoins. The matching server-mode fallback lives in runsInServerMode().
+    // (RELAY_MODE_UNLINKED) or non-toggle configuration would leave the relay hard to use. In that
+    // case fall back to the fresh-device dumb-switch behaviour: SWITCH_MODE_TOGGLE + RELAY_MODE_FRONT
+    // (a button click flips the relay). The persisted configuration in PDM (and the in-memory
+    // attribute values) are left untouched, so the original (e.g. decoupled/momentary) behaviour is
+    // restored automatically once the device rejoins. The server-mode fallback lives in runsInServerMode().
     bool offlineDumbSwitch = !clientOnly && !ZigbeeDevice::getInstance()->isJoined();
+    SwitchMode switchMode = offlineDumbSwitch
+                            ? SWITCH_MODE_TOGGLE
+                            : (SwitchMode)sOnOffConfigServerCluster.eSwitchMode;
     RelayMode relayMode = offlineDumbSwitch
                             ? RELAY_MODE_FRONT
                             : (RelayMode)sOnOffConfigServerCluster.eRelayMode;
 
-    buttonHandler.setConfiguration((SwitchMode)sOnOffConfigServerCluster.eSwitchMode,
+    buttonHandler.setConfiguration(switchMode,
                                    relayMode,
                                    sOnOffConfigServerCluster.iMaxPause,
                                    sOnOffConfigServerCluster.iMinLongPress);

--- a/src/SwitchEndpoint.h
+++ b/src/SwitchEndpoint.h
@@ -115,6 +115,7 @@ protected:
 
     virtual void restoreButtonsConfiguration();
     virtual void saveButtonsConfiguration();
+    virtual void applyButtonsConfiguration();
 
     virtual void initReportingConfigurations();
     virtual void saveReportingConfigurations();

--- a/src/ZigbeeDevice.cpp
+++ b/src/ZigbeeDevice.cpp
@@ -12,6 +12,9 @@ extern "C"
     #include "bdb_api.h"
     #include "dbg.h"
     #include "OnOff.h"
+
+    // Application API - for the radio compliance-limit call (vAppApiSetComplianceLimits)
+    #include "AppApi.h"
 }
 
 #include "ZigbeeDevice.h"
@@ -41,6 +44,14 @@ ZigbeeDevice::ZigbeeDevice()
 
     // Restore network connection state
     connectionState.init(NOT_JOINED, "connectionState");
+
+    // Standard JN5169 ETSI-region compliance ceiling (+8 dBm on all channels,
+    // CCA threshold 48), applied before the stack brings up the MAC/PHY. This
+    // does NOT by itself change the link budget - it only caps the core radio,
+    // which already sits below the cap, so on its own it had no measurable LQI
+    // effect. It is kept as an explicit legal ceiling for the amplified output
+    // once the external PA (below) is enabled.
+    vAppApiSetComplianceLimits(8, 8, 48);
 
     // Initialise Application Framework stack
     DBG_vPrintf(TRUE, "ZigbeeDevice(): init Application Framework (AF)... ");

--- a/src/ZigbeeDevice.cpp
+++ b/src/ZigbeeDevice.cpp
@@ -15,6 +15,9 @@ extern "C"
 
     // Application API - for the radio compliance-limit call (vAppApiSetComplianceLimits)
     #include "AppApi.h"
+
+    // Hardware API - for enabling the external RF front-end (vAHI_HighPowerModuleEnable)
+    #include "AppHardwareApi.h"
 }
 
 #include "ZigbeeDevice.h"
@@ -52,6 +55,17 @@ ZigbeeDevice::ZigbeeDevice()
     // effect. It is kept as an explicit legal ceiling for the amplified output
     // once the external PA (below) is enabled.
     vAppApiSetComplianceLimits(8, 8, 48);
+
+    // Enable the on-board AT2401C RF front-end module (PA + LNA + T/R switch).
+    // Its TXEN/RXEN control pins are wired (each via a 1k series resistor) to the
+    // JN5169 radio-control outputs RFTX (DIO3, pin 19) and RFRX (DIO2, pin 18);
+    // this call makes the radio auto-drive those lines so the PA engages on
+    // transmit and the LNA on receive. Without it the FEM stays in shutdown and
+    // the device transmits on the bare radio (~0 dBm) - the root cause of the
+    // weak uplink on stock hellozigbee. See doc/AT2401C_rf_frontend_RE.md.
+    // NB: on channel 26 use vAppApiSetHighPowerMode() instead (tighter ch26
+    // emission limits); this call is fine on channels 11-25.
+    vAHI_HighPowerModuleEnable(TRUE, TRUE);
 
     // Initialise Application Framework stack
     DBG_vPrintf(TRUE, "ZigbeeDevice(): init Application Framework (AF)... ");

--- a/src/ZigbeeDevice.cpp
+++ b/src/ZigbeeDevice.cpp
@@ -109,11 +109,12 @@ void ZigbeeDevice::leaveNetwork()
     if (ZPS_E_SUCCESS !=  ZPS_eAplZdoLeaveNetwork(0, FALSE, FALSE))
     {
         // Leave failed, probably lost parent, so just reset everything
+        // (this also notifies the endpoints via EndpointManager::handleDeviceLeave())
         DBG_vPrintf(TRUE, "== Failed to properly leave the network. Force leaving the network\n");
         handleLeaveNetwork();
     }
-
-    EndpointManager::getInstance()->handleDeviceLeave();
+    else
+        EndpointManager::getInstance()->handleDeviceLeave();
 }
 
 void ZigbeeDevice::joinOrLeaveNetwork()

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -94,7 +94,12 @@
 #define CLD_BAS_MANUF_NAME_SIZE                             3
 #define CLD_BAS_DATE_STR                                    BUILD_DATE
 #define CLD_BAS_DATE_SIZE                                   BUILD_DATE_LEN
-#define CLD_BAS_POWER_SOURCE                                E_CLD_BAS_PS_BATTERY
+// All current target boards (E75, QBKG11LM, QBKG12LM) are mains-powered Zigbee routers
+// (LogicalType="ZR", RxOnWhenIdle="true" in HelloZigbee.zpscfg). Report mains here so the Basic
+// cluster power-source attribute matches the node descriptor; otherwise coordinators (e.g. z2m)
+// treat the device as a sleepy battery node and defer OTA/availability handling. A future
+// battery/end-device board should override this in its own TARGET_BOARD_* section below.
+#define CLD_BAS_POWER_SOURCE                                E_CLD_BAS_PS_SINGLE_PHASE_MAINS
 #define CLD_BAS_SW_BUILD_STR                                VERSION_STR
 #define CLD_BAS_SW_BUILD_SIZE                               VERSION_STR_LEN
 #define CLD_BAS_DEVICE_CLASS                                (0)


### PR DESCRIPTION
Tested on hardware (1-gang QBKG11LM) and ready for review.

I've been running hellozigbee on a 1-gang QBKG11LM and hit a series of issues; this branch collects the fixes. The headline one is **enabling the on-board RF front-end (PA)** (item 9) — the firmware transmitted on the bare JN5169 radio and only reaches stock-Aqara range once the module's PA is switched on (see also `doc/AT2401C_rf_frontend_RE.md`). Happy to split this into clean per-issue PRs if you'd prefer that over one branch.

## Problems I hit (and what I did)

1. **A normal long press can accidentally leave the network.** Join and leave share one gesture (hold all buttons > 5 s). On a 1-gang device that's just holding the single button 5 s, so any hold-based use (e.g. a hold-to-dim automation) can accidentally kick the device off the network. → Split into asymmetric thresholds: ~5 s to **join**, ~30 s to **leave**. (Coordinator-side removal is the better way to leave anyway.)

2. **A decoupled / off-network device becomes an uncontrollable relay.** If the relay is decoupled (or the device leaves/loses the network), nothing can drive the relay — not the button (decoupled) and not the network (gone). → Added an off-network fallback: while NOT joined, drive the relay as a plain click-to-flip switch (`SWITCH_MODE_TOGGLE` + `RELAY_MODE_FRONT`), matching a fresh device. Nothing is persisted, so the configured (e.g. decoupled/momentary) behaviour is restored automatically on rejoin.

3. **Device advertises Battery power source though it's a mains router.** `CLD_BAS_POWER_SOURCE` was `E_CLD_BAS_PS_BATTERY` globally, but every board is a mains router (`LogicalType="ZR"`, `RxOnWhenIdle="true"`). Coordinators (Zigbee2MQTT) then treat it as a sleepy battery node and defer OTA / availability handling. → Report `E_CLD_BAS_PS_SINGLE_PHASE_MAINS`.

4. **Bug: `EndpointManager::handleDeviceLeave()` calls `handleDeviceJoin()`.** Copy-paste slip — the per-endpoint device-leave path never actually ran. → Fixed.

5. **Bug: OOSC defaults assign `eOperationMode` twice.** The second assignment uses an interlock constant, which clobbers the intended `SERVER` operation-mode default and leaves `eInterlockMode` uninitialised. → Fixed (assign `eInterlockMode`).

6. **Bug: `ButtonHandler::setConfiguration()` never applies `maxPause`.** The `maxPause` parameter shadows the `maxPause` member, so `maxPause = maxPause/ButtonPollCycle` assigns the divided value back into the *parameter* — the member keeps its old value. Net effect: the persisted `iMaxPause` is silently ignored on every boot (the constructor default of 250 ms stays in effect until an OTA write happens to call `setMaxPause()`). → Fixed by renaming the parameter, following the `sMode`/`rMode` convention already used in that signature to avoid exactly this shadowing.

7. **OOSC enum attributes accepted any byte over the air.** `handleCheckAttributeRange()` guarded only one case (client-only endpoints being switched to server mode); the other writable enum8 attributes (switch mode, switch actions, relay mode, long press mode, interlock mode) accepted out-of-range values — which got persisted to PDM and then treated as a no-op by the button state machines, i.e. one bad write could leave the physical button dead across reboots. → Range-validate all OOSC enum writes, rejecting with `INVALID_VALUE` like the existing operation-mode guard. (Also fixed on the way: `leaveNetwork()`'s failure path notified endpoints twice, and a stale cycle-math comment in `canSleep()`.)

8. **Gesture-counter refinements found while reviewing my own item 1** (relevant to upstream too, since the pre-existing 5 s gesture had the same semantics): (a) the hold counter counted how long *any* button was held while the gesture fired on *all buttons pressed* — on a 2-gang board a long single-button hold pre-charges the counter, so merely touching the second button fired an instant join/leave; the counter now only runs while all buttons are held. (b) Nothing prevented the gesture from re-firing while the buttons stayed pressed — a stuck button (the scenario the old source-code TODO warned about) would leave at 30 s, rejoin 5 s later, leave again, endlessly flapping on the network and wearing PDM flash with a `connectionState` write per transition; the gesture is now latched to fire at most once per continuous press.

9. **The device transmits far weaker than stock Aqara firmware (weak uplink, asymmetric LQI).** On hellozigbee the switch was heard poorly by its neighbours — the coordinator often couldn't hear it directly at all — while it heard everyone fine. That good-RX / deaf-TX asymmetry survived every *core-radio* power tweak. **Root cause:** the board carries an external **AT2401C** 2.4 GHz front-end module (PA + LNA + T/R switch — the "PA" in `LM15-LNS-`**`PA`**`-A-T0`, the "antenna amplifier" noted in doc part26), and hellozigbee never enables it — so the device transmits on the **bare JN5169 radio (~0 dBm)** while stock Aqara firmware drives the module's **+22 dBm PA**. → Enable it at radio init with **`vAHI_HighPowerModuleEnable(TRUE, TRUE)`**, which makes the radio auto-drive its RFTX/RFRX control outputs (DIO3/DIO2), wired via 1 kΩ to the module's TXEN/RXEN. Full chip pinout, reverse-engineered wiring and measurements are in **`doc/AT2401C_rf_frontend_RE.md`**.

   Verified with a controlled swap — same switch model in the **same wall socket**, hellozigbee+fix vs. stock Aqara firmware — by Zigbee networkmap inbound LQI (neighbour names anonymised):

   | neighbour hears it | PA off (before) | **PA on (fix)** | **stock Aqara FW** |
   |---|---|---|---|
   | Coordinator (direct) | — (unreachable) | 104 | 103 |
   | R1 | 58 | 186 | 185 |
   | R2 | 38 | 177 | 175 |
   | R3 | 0 | 147 | 152 |
   | R4 | 0 | 126 | 123 |
   | R5 | — | 100 | 88 |
   | R6 | — | 85 | 86 |
   | R7 | — | 85 | 80 |
   | R8 | — | 75 | 63 |
   | **median / max** | **0 / 58** | **104 / 186** | **103 / 185** |

   The fix reproduces the factory operating point to within a couple of LQI points on **every** link — it enables the PA exactly as stock does, without over-driving (nothing pegs at 255). Kept the existing `vAppApiSetComplianceLimits(...)` ETSI ceiling; the network is not on channel 26, so NXP's ch26 emission clause for this call doesn't apply.


## Related, fixed on the zigbee2mqtt converter side (separate, noted for context)

The matching Zigbee2MQTT external converter (needed to reproduce any of this — it exposes the custom `genOnOffSwitchCfg` attributes and configures the device) lives here:

**`midlan/zigbee-herdsman-converters` @ `add-hellozigbee`** — https://github.com/midlan/zigbee-herdsman-converters/tree/add-hellozigbee (`src/devices/hellozigbee.ts`)

Two converter bugs I hit while getting reconfigure to pass, fixed on that branch:

- Reconfigure failed because the converter read the **standard** `switchActions` (0x0010) as manufacturer-specific → `UNSUPPORTED_ATTRIBUTE` (the firmware registers it as standard). Fix: https://github.com/midlan/zigbee-herdsman-converters/commit/5cdc0028484fe52d7d1195ea2d892a3129e55b13
- Reconfigure also failed setting up reporting for `genDeviceTempCfg` / `currentTemperature`, which isn't reportable → disabled reporting there. Fix: https://github.com/midlan/zigbee-herdsman-converters/commit/2e368371272fe06611f3e7dbe6fea3eaa4fc32d5

## Note

Some commits on this branch are **fork-local build infrastructure** (a CI build-number offset and building the OTA image for flashing) and are **not** meant for merge — I'll drop/clean those before any real PR. The exploratory transmit-power commits here (a raw +10 dBm PHY write, then compliance-limits-only) are **superseded** by the AT2401C PA-enable (item 9) and would be squashed into it.

Feedback on direction very welcome.


