### PR TITLE
Split join/leave gesture, harden it, and add an off-network relay fallback

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -206,7 +206,7 @@ The device implements a common type of home automation devices. On the first sta
 
 Once the device joined the network, zigbee2mqtt will start intervieweing the device, which will take up to 15 seconds. If the zigbee2mqtt external converter is installed, the z2m system will provide full access to the device features.
 
-Device automatically tries to rejoin the network if network conditions change (e.g. parent/neighbour router no longer responds). Device joining and rejoining, as well as failure recovery is implemented using BDB component (a part of Zigbee SDK). The device performs several rejoin attempts before giving up. Pressing both device buttons for 5 seconds will force device to leave the network.
+Device automatically tries to rejoin the network if network conditions change (e.g. parent/neighbour router no longer responds). Device joining and rejoining, as well as failure recovery is implemented using BDB component (a part of Zigbee SDK). The device performs several rejoin attempts before giving up. Pressing and holding both device buttons for 30 seconds will force the device to leave the network (a deliberately longer hold than the 5 seconds used for joining, so that a normal long press - e.g. hold-to-dim - cannot accidentally trigger a leave). The device can also be removed from the coordinator side (e.g. via the Zigbee2MQTT "Remove device" function).
 
 ## Main functionality
 

--- a/src/ButtonsTask.cpp
+++ b/src/ButtonsTask.cpp
@@ -101,18 +101,32 @@ void ButtonsTask::timerCallback()
         longPressCounter = 0;
     }
 
-    // Process a very long press of all buttons to join/leave the network
-    // TODO: Perhaps just a long press is not a good key combination for join/rejoin. For example buttons may be accidentally
-    // pressed by to a heavy object. It may be reasonable to introduce some patter, e.g. press both button 2 times, and then hold.
-    if(longPressCounter > 5000/ButtonPollCycle && allButtonsPressed)
+    // Process a very long press of all buttons to join/leave the network.
+    // Join and leave use asymmetric thresholds so that an everyday long press (e.g. a
+    // hold-to-dim gesture routed through the button) can never accidentally leave the network:
+    //   - JOIN : all buttons held ~5s while NOT on a network (a fresh device is not running
+    //            any hold gesture, so a short threshold is safe and convenient).
+    //   - LEAVE: all buttons held ~30s while joined - deliberately long. Prefer removing the
+    //            device from the coordinator (e.g. Zigbee2MQTT "Remove device") over this
+    //            local escape hatch, which mainly exists for an orphaned device.
+    if(allButtonsPressed)
     {
-        for(uint8 h = 0; h < numHandlers; h++)
-            handlers[h].handler->resetButtonStateMachine();
+        ZigbeeDevice * zigbeeDevice = ZigbeeDevice::getInstance();
+        bool doJoin  = !zigbeeDevice->isJoined() && longPressCounter > 5000/ButtonPollCycle;
+        bool doLeave =  zigbeeDevice->isJoined() && longPressCounter > 30000/ButtonPollCycle;
 
-        longPressCounter = 0;
+        if(doJoin || doLeave)
+        {
+            for(uint8 h = 0; h < numHandlers; h++)
+                handlers[h].handler->resetButtonStateMachine();
 
-        // Perform the join/leave
-        ZigbeeDevice::getInstance()->joinOrLeaveNetwork();
+            longPressCounter = 0;
+
+            if(doJoin)
+                zigbeeDevice->joinNetwork();
+            else
+                zigbeeDevice->leaveNetwork();
+        }
     }
 }
 

--- a/src/ButtonsTask.cpp
+++ b/src/ButtonsTask.cpp
@@ -10,6 +10,7 @@ ButtonsTask::ButtonsTask()
 {
     idleCounter = 0;
     longPressCounter = 0;
+    gestureFired = false;
 
     buttonsMask = 0;
     buttonsOverride = 0;
@@ -91,14 +92,19 @@ void ButtonsTask::timerCallback()
 
     // Reset the idle counter when user interacts with a button
     if(someButtonPressed)
-    {
         idleCounter = 0;
+    else
+        idleCounter++;
+
+    // Count how long ALL buttons are held together (the join/leave gesture). Counting any-button
+    // presses instead would let a long single-button hold (e.g. hold-to-dim on a 2-gang device)
+    // pre-charge the counter, so that merely touching the second button would fire the gesture.
+    if(allButtonsPressed)
         longPressCounter++;
-    }
     else
     {
-        idleCounter++;
         longPressCounter = 0;
+        gestureFired = false;   // Buttons released - re-arm the gesture
     }
 
     // Process a very long press of all buttons to join/leave the network.
@@ -109,7 +115,10 @@ void ButtonsTask::timerCallback()
     //   - LEAVE: all buttons held ~30s while joined - deliberately long. Prefer removing the
     //            device from the coordinator (e.g. Zigbee2MQTT "Remove device") over this
     //            local escape hatch, which mainly exists for an orphaned device.
-    if(allButtonsPressed)
+    // At most one gesture fires per continuous press (gestureFired latch): without it a stuck
+    // button would leave at 30s, rejoin 5s later, leave again, and so on - endlessly flapping
+    // on the network and wearing PDM flash with connectionState writes on every transition.
+    if(allButtonsPressed && !gestureFired)
     {
         ZigbeeDevice * zigbeeDevice = ZigbeeDevice::getInstance();
         bool doJoin  = !zigbeeDevice->isJoined() && longPressCounter > 5000/ButtonPollCycle;
@@ -120,7 +129,7 @@ void ButtonsTask::timerCallback()
             for(uint8 h = 0; h < numHandlers; h++)
                 handlers[h].handler->resetButtonStateMachine();
 
-            longPressCounter = 0;
+            gestureFired = true;
 
             if(doJoin)
                 zigbeeDevice->joinNetwork();

--- a/src/ButtonsTask.h
+++ b/src/ButtonsTask.h
@@ -22,6 +22,7 @@ class ButtonsTask : public PeriodicTask
 {
     uint32 idleCounter;
     uint32 longPressCounter;
+    bool gestureFired;
 
     HandlerRecord handlers[ZCL_NUMBER_OF_ENDPOINTS+1];
     uint8 numHandlers;

--- a/src/SwitchEndpoint.cpp
+++ b/src/SwitchEndpoint.cpp
@@ -162,15 +162,12 @@ void SwitchEndpoint::restoreButtonsConfiguration()
                             sizeof(sOnOffConfigServerCluster),
                             &readBytes);
 
-    // Configure buttons state machine with read values
-    buttonHandler.setConfiguration((SwitchMode)sOnOffConfigServerCluster.eSwitchMode, 
-                                   (RelayMode)sOnOffConfigServerCluster.eRelayMode,
-                                   sOnOffConfigServerCluster.iMaxPause,
-                                   sOnOffConfigServerCluster.iMinLongPress);
-
     // Make sure that client only endpoints have client mode set
     if(clientOnly)
         sOnOffConfigServerCluster.eOperationMode = E_CLD_OOSC_OPERATION_MODE_CLIENT;
+
+    // Configure the buttons state machine, applying the off-network coupling fallback if needed
+    applyButtonsConfiguration();
 
     // Dump the restored configuration
     DBG_vPrintf(TRUE, "SwitchEndpoint EP=%d: Restored buttons configuration:\n", getEndpointId());
@@ -187,6 +184,25 @@ void SwitchEndpoint::saveButtonsConfiguration()
     PDM_eSaveRecordData(getPdmIdForEndpoint(getEndpointId(), PARAM_ID_BUTTON_CONFIG),
                         &sOnOffConfigServerCluster,
                         sizeof(sOnOffConfigServerCluster));
+}
+
+void SwitchEndpoint::applyButtonsConfiguration()
+{
+    // While the device is off the network it cannot be controlled over Zigbee, so a decoupled
+    // (RELAY_MODE_UNLINKED) configuration would leave the relay stuck and uncontrollable. In that
+    // case fall back to a coupled RELAY_MODE_FRONT so the physical button keeps working like a
+    // plain switch. The persisted configuration in PDM (and the in-memory attribute values) are
+    // left untouched, so the original (e.g. decoupled) behaviour is restored automatically once
+    // the device rejoins. The matching server-mode fallback lives in runsInServerMode().
+    bool offlineDumbSwitch = !clientOnly && !ZigbeeDevice::getInstance()->isJoined();
+    RelayMode relayMode = offlineDumbSwitch
+                            ? RELAY_MODE_FRONT
+                            : (RelayMode)sOnOffConfigServerCluster.eRelayMode;
+
+    buttonHandler.setConfiguration((SwitchMode)sOnOffConfigServerCluster.eSwitchMode,
+                                   relayMode,
+                                   sOnOffConfigServerCluster.iMaxPause,
+                                   sOnOffConfigServerCluster.iMinLongPress);
 }
 
 void SwitchEndpoint::init()
@@ -664,6 +680,12 @@ bool SwitchEndpoint::runsInServerMode() const
     if(clientOnly)
         return false;
 
+    // Off the network the endpoint always acts as a local server, so the relay stays controllable
+    // by the physical button (paired with the coupling fallback in applyButtonsConfiguration()).
+    // The persisted operation mode is honoured again once the device is back on the network.
+    if(!ZigbeeDevice::getInstance()->isJoined())
+        return true;
+
     bool serverMode = (sOnOffConfigServerCluster.eOperationMode == E_CLD_OOSC_OPERATION_MODE_SERVER);
     DBG_vPrintf(TRUE, "SwitchEndpoint EP=%d: ServerMode=%d (mode=%d)\n", getEndpointId(), serverMode, sOnOffConfigServerCluster.eOperationMode);
     return serverMode;
@@ -671,12 +693,18 @@ bool SwitchEndpoint::runsInServerMode() const
 
 void SwitchEndpoint::handleDeviceJoin()
 {
+    // Back on the network: restore the configured (possibly decoupled) button behaviour
+    applyButtonsConfiguration();
+
     // Force resetting the LED
     doStateChange(getState());
 }
 
 void SwitchEndpoint::handleDeviceLeave()
 {
+    // Off the network: fall back to a coupled local switch so the relay stays usable
+    applyButtonsConfiguration();
+
     // Force resetting the LED
     doStateChange(getState());
 }

--- a/src/SwitchEndpoint.cpp
+++ b/src/SwitchEndpoint.cpp
@@ -189,17 +189,20 @@ void SwitchEndpoint::saveButtonsConfiguration()
 void SwitchEndpoint::applyButtonsConfiguration()
 {
     // While the device is off the network it cannot be controlled over Zigbee, so a decoupled
-    // (RELAY_MODE_UNLINKED) configuration would leave the relay stuck and uncontrollable. In that
-    // case fall back to a coupled RELAY_MODE_FRONT so the physical button keeps working like a
-    // plain switch. The persisted configuration in PDM (and the in-memory attribute values) are
-    // left untouched, so the original (e.g. decoupled) behaviour is restored automatically once
-    // the device rejoins. The matching server-mode fallback lives in runsInServerMode().
+    // (RELAY_MODE_UNLINKED) or non-toggle configuration would leave the relay hard to use. In that
+    // case fall back to the fresh-device dumb-switch behaviour: SWITCH_MODE_TOGGLE + RELAY_MODE_FRONT
+    // (a button click flips the relay). The persisted configuration in PDM (and the in-memory
+    // attribute values) are left untouched, so the original (e.g. decoupled/momentary) behaviour is
+    // restored automatically once the device rejoins. The server-mode fallback lives in runsInServerMode().
     bool offlineDumbSwitch = !clientOnly && !ZigbeeDevice::getInstance()->isJoined();
+    SwitchMode switchMode = offlineDumbSwitch
+                            ? SWITCH_MODE_TOGGLE
+                            : (SwitchMode)sOnOffConfigServerCluster.eSwitchMode;
     RelayMode relayMode = offlineDumbSwitch
                             ? RELAY_MODE_FRONT
                             : (RelayMode)sOnOffConfigServerCluster.eRelayMode;
 
-    buttonHandler.setConfiguration((SwitchMode)sOnOffConfigServerCluster.eSwitchMode,
+    buttonHandler.setConfiguration(switchMode,
                                    relayMode,
                                    sOnOffConfigServerCluster.iMaxPause,
                                    sOnOffConfigServerCluster.iMinLongPress);

--- a/src/SwitchEndpoint.h
+++ b/src/SwitchEndpoint.h
@@ -115,6 +115,7 @@ protected:
 
     virtual void restoreButtonsConfiguration();
     virtual void saveButtonsConfiguration();
+    virtual void applyButtonsConfiguration();
 
     virtual void initReportingConfigurations();
     virtual void saveReportingConfigurations();


### PR DESCRIPTION
Split out of #19 per review (items 1, 2 and 8 of its description). Tested on hardware (1-gang QBKG11LM); builds verified for QBKG11LM and EBYTE_E75.

1. **A normal long press could accidentally leave the network.** Join and leave shared one gesture (hold all buttons > 5 s) — on a 1-gang device any hold-based use could kick the device off the network. → Split into asymmetric thresholds: ~5 s to **join**, ~30 s to **leave**.

2. **A decoupled / off-network device became an uncontrollable relay.** With the relay decoupled and the network gone, nothing could drive the relay. → While NOT joined, the device falls back to a plain click-to-flip switch (`SWITCH_MODE_TOGGLE` + `RELAY_MODE_FRONT`), matching a fresh device. Nothing is persisted, so the configured behaviour restores automatically on rejoin.

3. **Gesture-counter hardening** (pre-existing semantics, also affected upstream's single 5 s gesture): (a) the hold counter ran while *any* button was held although the gesture fires on *all* buttons — on a 2-gang board a long single-button hold pre-charged the counter so touching the second button fired instantly; the counter now only runs while all buttons are held. (b) The gesture could re-fire while buttons stayed pressed — a stuck button would flap join/leave endlessly (with a PDM write per transition); it is now latched to fire at most once per continuous press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxTanjAztZW5G7fkHFaCjZ