### PR TITLE
Fix five oversights: power source, leave dispatch, OOSC defaults/validation, maxPause

### DIFF
--- a/src/ButtonHandler.cpp
+++ b/src/ButtonHandler.cpp
@@ -47,13 +47,13 @@ const char * ButtonHandler::getStateName(ButtonState state)
     return "";
 }
 
-void ButtonHandler::setConfiguration(SwitchMode sMode, RelayMode rMode, uint16 maxPause, uint16 minLongPress)
+void ButtonHandler::setConfiguration(SwitchMode sMode, RelayMode rMode, uint16 maxPauseMs, uint16 minLongPress)
 {
     // This function does the same as 4 functions below all together, but as a single transaction.
     // This is needed to avoid cluttering log with multiple changeState messages
     switchMode = sMode;
     relayMode = rMode;
-    maxPause = maxPause/ButtonPollCycle;
+    maxPause = maxPauseMs/ButtonPollCycle;
     longPressDuration = minLongPress/ButtonPollCycle;
 
     changeState(INVALID, true);

--- a/src/ButtonsTask.cpp
+++ b/src/ButtonsTask.cpp
@@ -48,7 +48,7 @@ bool ButtonsTask::handleDioInterrupt(uint32 dioStatus)
 
 bool ButtonsTask::canSleep() const
 {
-    return idleCounter > 5000 / ButtonPollCycle; // 500 cycles * 10 ms = 5 sec
+    return idleCounter > 5000 / ButtonPollCycle; // 250 cycles * 20 ms = 5 sec
 }
 
 void ButtonsTask::registerHandler(uint32 pinMask, IButtonHandler * handler)

--- a/src/EndpointManager.cpp
+++ b/src/EndpointManager.cpp
@@ -101,5 +101,5 @@ void EndpointManager::handleDeviceJoin()
 void EndpointManager::handleDeviceLeave()
 {
     for(uint8 ep = 1; ep <= ZCL_NUMBER_OF_ENDPOINTS; ep++)
-        registry[ep]->handleDeviceJoin();
+        registry[ep]->handleDeviceLeave();
 }

--- a/src/OOSC.c
+++ b/src/OOSC.c
@@ -76,7 +76,7 @@ PUBLIC  teZCL_Status eCLD_OOSCCreateOnOffSwitchConfig(
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->iMinLongPress = 1000;
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eLongPressMode = E_CLD_OOSC_LONG_PRESS_MODE_NONE;
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eOperationMode = E_CLD_OOSC_OPERATION_MODE_SERVER;
-            ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eOperationMode = E_CLD_OOSC_INTERLOCK_MODE_NONE;
+            ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->eInterlockMode = E_CLD_OOSC_INTERLOCK_MODE_NONE;
 #endif
             ((tsCLD_OOSC*)psClusterInstance->pvEndPointSharedStructPtr)->u16ClusterRevision = CLD_OOSC_CLUSTER_REVISION;
         }

--- a/src/SwitchEndpoint.cpp
+++ b/src/SwitchEndpoint.cpp
@@ -623,15 +623,55 @@ teZCL_CommandStatus SwitchEndpoint::handleCheckAttributeRange(tsZCL_CallBackEven
     uint16 attribute = psEvent->uMessage.sIndividualAttributeResponse.u16AttributeEnum;
     uint16 cluster = psEvent->psClusterInstance->psClusterDefinition->u16ClusterEnum;
 
-    // Prevent switching client only endpoint to a server mode
-    if(cluster == GENERAL_CLUSTER_ID_ONOFF_SWITCH_CONFIGURATION && attribute == E_CLD_OOSC_ATTR_ID_SWITCH_OPERATION_MODE)
+    // Validate values written to the OOSC enum attributes. The ZCL layer only checks the type
+    // width (enum8), not the value, and an out-of-range value would be persisted in PDM (thus
+    // surviving reboots) while the button handlers treat unknown values as a no-op - i.e. a
+    // single bad write could disable the physical button until a valid value is rewritten.
+    if(cluster == GENERAL_CLUSTER_ID_ONOFF_SWITCH_CONFIGURATION)
     {
         uint8 value = *(uint8*)psEvent->uMessage.sIndividualAttributeResponse.pvAttributeData;
-        if(clientOnly && value != E_CLD_OOSC_OPERATION_MODE_CLIENT)
-            return E_ZCL_CMDS_INVALID_VALUE;
+
+        switch(attribute)
+        {
+            case E_CLD_OOSC_ATTR_ID_SWITCH_OPERATION_MODE:
+                // Also prevent switching client only endpoint to a server mode
+                if(clientOnly && value != E_CLD_OOSC_OPERATION_MODE_CLIENT)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                if(value > E_CLD_OOSC_OPERATION_MODE_CLIENT)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_MODE:
+                if(value > SWITCH_MODE_MULTIFUNCTION)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_ACTIONS:
+                if(value > E_CLD_OOSC_ACTION_TOGGLE)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_RELAY_MODE:
+                if(value > RELAY_MODE_LONG)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_LONG_PRESS_MODE:
+                if(value > E_CLD_OOSC_LONG_PRESS_MODE_LEVEL_CTRL_DOWN)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            case E_CLD_OOSC_ATTR_ID_SWITCH_INTERLOCK_MODE:
+                if(value > E_CLD_OOSC_INTERLOCK_MODE_OPPOSITE)
+                    return E_ZCL_CMDS_INVALID_VALUE;
+                break;
+
+            default:
+                break;
+        }
     }
 
-    // By default we do not perform attribute value validation
+    // Other attributes are not range-validated
     return E_ZCL_CMDS_SUCCESS;
 }
 

--- a/src/ZigbeeDevice.cpp
+++ b/src/ZigbeeDevice.cpp
@@ -109,11 +109,12 @@ void ZigbeeDevice::leaveNetwork()
     if (ZPS_E_SUCCESS !=  ZPS_eAplZdoLeaveNetwork(0, FALSE, FALSE))
     {
         // Leave failed, probably lost parent, so just reset everything
+        // (this also notifies the endpoints via EndpointManager::handleDeviceLeave())
         DBG_vPrintf(TRUE, "== Failed to properly leave the network. Force leaving the network\n");
         handleLeaveNetwork();
     }
-
-    EndpointManager::getInstance()->handleDeviceLeave();
+    else
+        EndpointManager::getInstance()->handleDeviceLeave();
 }
 
 void ZigbeeDevice::joinOrLeaveNetwork()

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -94,7 +94,12 @@
 #define CLD_BAS_MANUF_NAME_SIZE                             3
 #define CLD_BAS_DATE_STR                                    BUILD_DATE
 #define CLD_BAS_DATE_SIZE                                   BUILD_DATE_LEN
-#define CLD_BAS_POWER_SOURCE                                E_CLD_BAS_PS_BATTERY
+// All current target boards (E75, QBKG11LM, QBKG12LM) are mains-powered Zigbee routers
+// (LogicalType="ZR", RxOnWhenIdle="true" in HelloZigbee.zpscfg). Report mains here so the Basic
+// cluster power-source attribute matches the node descriptor; otherwise coordinators (e.g. z2m)
+// treat the device as a sleepy battery node and defer OTA/availability handling. A future
+// battery/end-device board should override this in its own TARGET_BOARD_* section below.
+#define CLD_BAS_POWER_SOURCE                                E_CLD_BAS_PS_SINGLE_PHASE_MAINS
 #define CLD_BAS_SW_BUILD_STR                                VERSION_STR
 #define CLD_BAS_SW_BUILD_SIZE                               VERSION_STR_LEN
 #define CLD_BAS_DEVICE_CLASS                                (0)


### PR DESCRIPTION
Split out of #19 per review (items 3–7 of its description). Tested on hardware (1-gang QBKG11LM); builds verified for QBKG11LM and EBYTE_E75.

1. **Device advertised Battery power source though it's a mains router** — coordinators treated it as a sleepy battery node and deferred OTA/availability handling. → `E_CLD_BAS_PS_SINGLE_PHASE_MAINS`.
2. **`EndpointManager::handleDeviceLeave()` called `handleDeviceJoin()`** (copy-paste slip) — the per-endpoint device-leave path never ran. → Fixed.
3. **OOSC defaults assigned `eOperationMode` twice** — the second assignment used an interlock constant, clobbering the operation-mode default and leaving `eInterlockMode` uninitialised. → Assign `eInterlockMode`.
4. **`ButtonHandler::setConfiguration()` never applied `maxPause`** — parameter shadowed the member, so the persisted `iMaxPause` was silently ignored on every boot. → Renamed the parameter (following the existing `sMode`/`rMode` convention).
5. **OOSC enum attributes accepted any byte over the air** — out-of-range values got persisted to PDM and treated as a no-op by the button state machines, i.e. one bad write could leave the physical button dead across reboots. → Range-validate all OOSC enum writes with `INVALID_VALUE`, like the existing operation-mode guard. (On the way: `leaveNetwork()`'s failure path no longer notifies endpoints twice, and a stale cycle-math comment in `canSleep()` is fixed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxTanjAztZW5G7fkHFaCjZ