### PR TITLE
Gate the RF front-end enable to boards that have the module

### DIFF
--- a/src/ZigbeeDevice.cpp
+++ b/src/ZigbeeDevice.cpp
@@ -56,16 +56,20 @@ ZigbeeDevice::ZigbeeDevice()
     // once the external PA (below) is enabled.
     vAppApiSetComplianceLimits(8, 8, 48);
 
-    // Enable the on-board AT2401C RF front-end module (PA + LNA + T/R switch).
-    // Its TXEN/RXEN control pins are wired (each via a 1k series resistor) to the
-    // JN5169 radio-control outputs RFTX (DIO3, pin 19) and RFRX (DIO2, pin 18);
-    // this call makes the radio auto-drive those lines so the PA engages on
-    // transmit and the LNA on receive. Without it the FEM stays in shutdown and
-    // the device transmits on the bare radio (~0 dBm) - the root cause of the
-    // weak uplink on stock hellozigbee. See doc/AT2401C_rf_frontend_RE.md.
+#ifdef SUPPORTS_RF_FRONTEND
+    // Enable the on-board RF front-end module (PA + LNA + T/R switch, e.g. the
+    // AT2401C on the QBKG boards). Its TXEN/RXEN control pins are wired (each via
+    // a 1k series resistor) to the JN5169 radio-control outputs RFTX (DIO3, pin 19)
+    // and RFRX (DIO2, pin 18); this call makes the radio auto-drive those lines so
+    // the PA engages on transmit and the LNA on receive. Without it the FEM stays
+    // in shutdown and the device transmits on the bare radio (~0 dBm) - the root
+    // cause of the weak uplink on stock hellozigbee. See doc/AT2401C_rf_frontend_RE.md.
     // NB: on channel 26 use vAppApiSetHighPowerMode() instead (tighter ch26
     // emission limits); this call is fine on channels 11-25.
+    // Gated per board: the call surrenders DIO2/DIO3 to the radio, so on boards
+    // without a FEM it must stay off (on EBYTE_E75 DIO2 is the second button).
     vAHI_HighPowerModuleEnable(TRUE, TRUE);
+#endif
 
     // Initialise Application Framework stack
     DBG_vPrintf(TRUE, "ZigbeeDevice(): init Application Framework (AF)... ");

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -148,6 +148,10 @@
     #define LED1_BLUE_PIN_2             (4)
     #define LED1_BLUE_MASK_OR_TIMER     (1UL << LED1_BLUE_PIN_1) | (1UL << LED1_BLUE_PIN_2)
 
+    // On-board RF front-end module (PA/LNA, AT2401C or pin-compatible): the radio
+    // drives its TXEN/RXEN via RFTX/RFRX (DIO3/DIO2) when enabled at init
+    #define SUPPORTS_RF_FRONTEND
+
     #define RELAY1_ON_PIN               (13)
     #define RELAY1_ON_MASK              (1UL << RELAY1_ON_PIN)
     #define RELAY1_OFF_PIN              (12)
@@ -187,6 +191,10 @@
     #define RELAY2_ON_MASK              (1UL << RELAY2_ON_PIN)
     #define RELAY2_OFF_PIN              (12)
     #define RELAY2_OFF_MASK             (1UL << RELAY2_OFF_PIN)
+
+    // On-board RF front-end module (PA/LNA, AT2401C or pin-compatible): the radio
+    // drives its TXEN/RXEN via RFTX/RFRX (DIO3/DIO2) when enabled at init
+    #define SUPPORTS_RF_FRONTEND
 
     #define BASIC_ENDPOINT              (QBKG12LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG12LM_SWITCH1_ENDPOINT)


### PR DESCRIPTION
Follow-up to #23, prompted by the review question there about the EBYTE_E75.

`vAHI_HighPowerModuleEnable()` surrenders DIO2/DIO3 to the radio as RFRX/RFTX, and #23 called it unconditionally on every board. The E75 module has no front-end chip (bare JN5169 radio) — and its board config uses **DIO2 as the second button**, so the ungated call would have taken that pin over. The call is now behind `SUPPORTS_RF_FRONTEND`, defined in the board sections for QBKG11LM (verified on hardware) and QBKG12LM (same board family — the FEM is the "antenna amplifier" observed on the 2-gang board).

Builds verified for QBKG11LM, QBKG12LM and EBYTE_E75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxTanjAztZW5G7fkHFaCjZ