### PR TITLE
WIP: HLW8012 power metering for QBKG11LM (W / V / A / kWh over standard clusters)

### DIFF
--- a/doc/QBKG_HLW8012_power_metering.md
+++ b/doc/QBKG_HLW8012_power_metering.md
@@ -1,0 +1,138 @@
+# QBKG11LM — HLW8012 power metering driver
+
+Power/energy metering support for the Aqara **QBKG11LM** with-neutral wall switch
+(board `LM15-LNS-PA-A-T0`, NXP **JN5169**) in the **hellozigbee** firmware, driving the
+on-board **HLW8012** energy-metering IC. The device exposes **active power (W)**,
+**RMS voltage (V)**, **RMS current (A)** and **cumulative energy (kWh)** over standard
+ZCL clusters, with attribute reporting, so zigbee2mqtt renders them natively.
+
+The hardware reverse-engineering (signal tracing, board constants, safety notes) is
+documented separately in `QBKG_HLW8012_power_metering_RE.md`. This document covers the
+driver design, the calibration method, and the coordinator-side integration, including
+several non-obvious SDK and zigbee2mqtt pitfalls.
+
+Advantage over stock Aqara firmware: stock only refreshes the power value when the relay
+switches (zigbee2mqtt#1744); this driver measures and reports continuously.
+
+## Acquisition — hardware pulse counters, hardware timebase
+
+The HLW8012 outputs frequencies, not registers:
+
+| HLW8012 pin | meaning | JN5169 | peripheral |
+|---|---|---|---|
+| CF | active power (freq ∝ W); each pulse = fixed energy | DIO8 | Pulse Counter 1 |
+| CF1 | RMS current *or* voltage, selected by SEL | DIO1 | Pulse Counter 0 |
+| SEL | CF1 mode select (inverted by a 2N7002 on this board) | DIO9 | GPIO out |
+
+Lucky break: PC0/PC1 default to exactly these DIOs — no remapping. Both counters run
+**free-running** (rising edge, debounce off, not combined, no interrupts) and are sampled
+once per second by `EnergyMeterTask`; uint16 wrap-around deltas absorb counter overflow
+and the documented spurious +1 of `bAHI_StartPulseCounter()`.
+
+**Do not assume the sampling window is 1 s.** The ZTIMER callback jitters whenever the
+main loop is busy (observed ±25 % under radio storms — a brushed-motor load next to the
+antenna is an effective jammer), and since both channels scale by the same wrong factor
+the corrupted readings look internally consistent. Timer 0 free-runs as a timebase
+(16 MHz / 2^14 = 976.5625 Hz; DIO takeover disabled — its pins overlap CF/SEL/button)
+and every window computes `freq = pulses × 78125 / (ticks × 8)`, immune to callback
+jitter. Frequencies are kept in 0.1 Hz units ("dHz").
+
+**SEL multiplexing:** the polarity had to be resolved empirically — with DIO9 driven low
+CF1 outputs *voltage* pulses (the 2N7002 inverts on the way to the chip). SEL alternates
+every 5 windows; the window straddling a toggle is discarded (mode change + HLW8012
+settle) and each mode keeps its last valid frequency, so voltage stays fresh while
+current is measured.
+
+## Calibration — integrate counts, then anchor to references
+
+Datasheet-nominal multipliers (from V_REF 2.43 V, F_OSC 3.579 MHz, divider ratio 1881,
+shunt 2 mΩ — the xoseperez/hlw8012 formulas) were off by several percent on the tested
+unit: component tolerances are real (the shunt measured ~9 % under its marking).
+
+Method that works over the air:
+
+1. The firmware exposes **cumulative CF/CF1 pulse counts** in two manufacturer-specific
+   uint32 attributes of the Electrical Measurement cluster (0xFF00/0xFF01, manufacturer
+   code 0x1037). Reading counts twice a few minutes apart under a steady load gives the
+   average frequency immune to any per-window noise and radio dropouts.
+2. **Power:** anchor CF frequency to a plug-through power meter reading taken in the same
+   interval (`K_P = W_meter / f_CF`). One tested unit: 4.5004 W/Hz vs 4.138 nominal.
+3. **Voltage:** anchor CF1 (voltage mode) to a multimeter reading at the load terminals,
+   taken under load so the sag is included.
+4. **Current:** no reference instrument needed — all three HLW8012 channels share V_REF
+   and the shunt, so the gains obey `K_P = K_V × K_I` and `K_I = K_P / K_V` follows
+   algebraically (power-factor independent). Cross-check: the implied PF for a
+   heater+motor load should land just below 1 (0.966 measured).
+
+The constants live in the board section of `zcl_options.h` (`METERING_W_PER_DHZ_E5`
+etc., scaled by 1e5 for integer math). They are **specimen-specific** — recalibrate per
+unit, or expect a few percent error from copying another unit's values.
+
+## ZCL exposure
+
+Both clusters sit on the basic (common) endpoint, next to DeviceTemperature:
+
+- **Electrical Measurement (0x0B04):** `activePower` (W, multiplier 1 / divisor 1),
+  `rmsVoltage` (0.1 V, divisor 10), `rmsCurrent` (mA, divisor 1000), plus the cumulative
+  count attributes above.
+- **Simple Metering (0x0702):** `currentSummationDelivered` in Wh (multiplier 1 /
+  divisor 1000 → kWh), derived from the lifetime CF count — each pulse is a fixed energy
+  quantum (`K_P` joules), so the count *is* the energy register.
+
+The energy register is persisted via PDM with a wear-aware policy: saved every
+~0.1 kWh of accumulation, or daily if any unsaved energy exists. Power-cut loss is
+bounded by ~0.1 kWh; EEPROM endurance stays comfortable for decades.
+
+### SDK pitfall #1 — two independent "reportable" flags
+
+Making these attributes reportable requires **both**:
+
+- `E_ZCL_AF_RP` in the attribute definition table — the reporting engine and
+  `eZCL_ReportAttribute()` silently skip attributes without it. The SDK tables ship
+  read-only, so patched copies of `ElectricalMeasurement.c` / `SimpleMetering.c` are
+  vendored into `src/` (the delta is only this flag).
+- `E_ZCL_ACF_RP` in the per-instance attribute *control bits* — the configure-reporting
+  command handler checks this one and answers `UNREPORTABLE_ATTRIBUTE` otherwise. Set at
+  runtime with `eZCL_SetReportableFlag()` after cluster registration.
+
+### SDK pitfall #2 — the reporting engine samples structs directly
+
+The engine reads the cluster storage structs without invoking any application hook, so
+updating attributes lazily in the read handler would report stale values. The meter task
+pushes fresh values into the structs every sampling window instead.
+
+(Also: the SDK gates the Simple Metering source on `CLD_SIMPLE_METERING` but its header
+structs on `CLD_SM`/`SM_SERVER` — define all three.)
+
+## zigbee2mqtt integration
+
+The external converter adds `m.electricityMeter()` to the QBKG11LM definition — power,
+voltage, current and energy render as native entities and reporting is configured by the
+standard z2m configure flow.
+
+### zigbee-herdsman pitfall — OTA never applies with an unsynced clock
+
+zigbee-herdsman (z2m ≥ 2.x) sends the OTA `upgradeEndResponse` with
+`currentTime = <real ZCL-UTC>` and `upgradeTime = currentTime + 1`. The NXP OTA client
+only schedules *relative* to receipt when `currentTime == 0`; otherwise it arms an
+absolute compare against its **own UTC clock**, which on a device with no Time cluster
+counts from 0 at boot — the upgrade gets scheduled ~26 years out and the device never
+reboots (transfer and CRC succeed; the client then sits in COUNT_DOWN state ignoring all
+further OTA frames). The code even carries a TODO suspecting this
+(`controller/model/device.js`, "could this tiny offset be a problem for some stacks?").
+
+Workarounds until fixed upstream: patch `device.js` to send `currentTime: 0,
+upgradeTime: 1`, or simply **power-cycle the stuck device** — this firmware's
+`restoreOTAAttributes()` clamps any pending OTA schedule to "retry in 10 s" on boot,
+which applies the already-downloaded image.
+
+## Known limitations
+
+- The current channel is derived (see calibration) and carries a ~30 mA noise floor at
+  zero load (HLW8012 low-end SNR; the stock firmware's low-load readings suffer the same
+  way). Could be zero-clamped when the relay is off.
+- QBKG12LM very likely carries the same metering circuit, but its HLW8012→DIO wiring has
+  not been verified, so the driver is enabled for QBKG11LM only
+  (`SUPPORTS_POWER_METERING` in `zcl_options.h`).
+- Low loads produce sub-Hz CF (0.5 W ≈ 0.12 Hz): 1 s windows legitimately read 0 W
+  between pulses. The energy register integrates correctly regardless.

--- a/doc/QBKG_HLW8012_power_metering.md
+++ b/doc/QBKG_HLW8012_power_metering.md
@@ -110,22 +110,6 @@ The external converter adds `m.electricityMeter()` to the QBKG11LM definition �
 voltage, current and energy render as native entities and reporting is configured by the
 standard z2m configure flow.
 
-### zigbee-herdsman pitfall — OTA never applies with an unsynced clock
-
-zigbee-herdsman (z2m ≥ 2.x) sends the OTA `upgradeEndResponse` with
-`currentTime = <real ZCL-UTC>` and `upgradeTime = currentTime + 1`. The NXP OTA client
-only schedules *relative* to receipt when `currentTime == 0`; otherwise it arms an
-absolute compare against its **own UTC clock**, which on a device with no Time cluster
-counts from 0 at boot — the upgrade gets scheduled ~26 years out and the device never
-reboots (transfer and CRC succeed; the client then sits in COUNT_DOWN state ignoring all
-further OTA frames). The code even carries a TODO suspecting this
-(`controller/model/device.js`, "could this tiny offset be a problem for some stacks?").
-
-Workarounds until fixed upstream: patch `device.js` to send `currentTime: 0,
-upgradeTime: 1`, or simply **power-cycle the stuck device** — this firmware's
-`restoreOTAAttributes()` clamps any pending OTA schedule to "retry in 10 s" on boot,
-which applies the already-downloaded image.
-
 ## Known limitations
 
 - The current channel is derived (see calibration) and carries a ~30 mA noise floor at

--- a/doc/QBKG_HLW8012_power_metering_RE.md
+++ b/doc/QBKG_HLW8012_power_metering_RE.md
@@ -86,6 +86,36 @@ JN5169 pin 32 = DIO9 ─ JP1 pin 7 ─ TP2 ─ 2N7002 (N-MOSFET, marked "702") �
 
 ---
 
+## 3a. Analog front‑end — current shunt & voltage divider (measured)
+
+These are the two board constants that set the pulse‑frequency → physical‑unit scaling.
+
+### Current shunt (V1P/V1N, pins 2/3)
+- **R002 = 0.002 Ω (2 mΩ)** — in series **between L and L1**; all load current flows through it.
+- SMD low‑value code (`R` = decimal point). Sense voltage: 10 A → 20 mV, 16 A → 32 mV — within the HLW8012 ±43.75 mV V1 range; I²R at 10 A ≈ 0.2 W.
+
+### Voltage divider (V2P, pin 4 = **TP16**)
+```
+N ──[ 4 × 470 kΩ (4703) = 1.88 MΩ ]── V2P / TP16 (pin 4) ──[ 1 kΩ (018) ]── L (=GND)
+         Rup (high side)                                      Rdown (low side)
+```
+- **Rup = 4 × 470 kΩ = 1.88 MΩ** — SMD `4703` (1%, 4‑digit code `470×10³`), a series string near the mains input.
+- **Rdown = 1 kΩ** — marked `018`, measured 1.00 kΩ (ohm mode, 2 kΩ range).
+- **Divider ratio = (Rup + Rdown)/Rdown = 1881.**
+- V2P at 230 V ≈ 230 × 1000/1,881,000 ≈ **122 mV RMS** — within the HLW8012 V2 range.
+
+> The nearby **~22 Ω through‑hole flameproof resistor** (bands red‑red‑black‑gold, measured 21.2 Ω) is the **SMPS mains inrush / fusible safety resistor** in the supply input — **not** part of the metering divider. Ignore it for calibration (22 Ω vs 1.88 MΩ is negligible even if in series).
+
+### Initial multipliers (xoseperez/hlw8012 formula — V_REF = 2.43, F_OSC = 3.579 MHz)
+Driver setup equivalent: `setResistors(current = 0.002, v_upstream = 1.88e6, v_downstream = 1000)`.
+- current_multiplier ≈ **7.2 × 10³**
+- voltage_multiplier ≈ **3.3 × 10⁵**
+- power_multiplier   ≈ **4.1 × 10⁶**
+
+These are **theoretical**; shunt / V_REF / F_OSC tolerances shift them a few %. **Trim against a reference meter on a known resistive load** (per §6).
+
+---
+
 ## 4. Connectors (board‑to‑board)
 
 Two 8‑pin (4×2) headers, dot = pin 1, **zig‑zag** numbering (`1 2 / 3 4 / 5 6 / 7 8`).
@@ -118,6 +148,7 @@ Metering uses **JP1** and **JP2** (JP1 carries most of it).
 | TP8 | HLW8012 CF (pin 6, raw 5 V) |
 | TP9 | CF divider **tap** (3.0 V) → JP2 pin 8 |
 | TP11 | **GND / common — tied to mains L** (reference for both dividers, 2N7002 source, HLW8012 GND) |
+| TP16 | HLW8012 **V2P** (pin 4) — voltage‑sense divider tap (Rup 1.88 MΩ ↔ Rdown 1 kΩ) |
 
 ---
 
@@ -149,7 +180,7 @@ Metering uses **JP1** and **JP2** (JP1 carries most of it).
 
 ## 7. TODO
 
-- [ ] Read/measure shunt + voltage‑divider values → calibration constants.
+- [x] Read/measure shunt + voltage‑divider values → calibration constants. **(shunt 2 mΩ; divider Rup 1.88 MΩ / Rdown 1 kΩ, ratio 1881 — see §3a)**
 - [ ] Determine SEL (DIO9) active polarity empirically (2N7002 inverts).
 - [ ] Implement PC0/PC1 pulse‑counter driver + SEL toggling.
 - [ ] Add `haElectricalMeasurement` / `seMetering` clusters + reporting.

--- a/doc/QBKG_HLW8012_power_metering_RE.md
+++ b/doc/QBKG_HLW8012_power_metering_RE.md
@@ -96,15 +96,16 @@ These are the two board constants that set the pulse‑frequency → physical‑
 
 ### Voltage divider (V2P, pin 4 = **TP16**)
 ```
-N ──[ 4 × 470 kΩ (4703) = 1.88 MΩ ]── V2P / TP16 (pin 4) ──[ 1 kΩ (018) ]── L (=GND)
-         Rup (high side)                                      Rdown (low side)
+N ──[ 22 Ω fusible ]──┬──[ 4 × 470 kΩ (4703) = 1.88 MΩ ]── V2P / TP16 (pin 4) ──[ 1 kΩ (018) ]── L (=GND)
+                      └──► SMPS input / rest of circuit
+        Rup (high side)                                       Rdown (low side)
 ```
-- **Rup = 4 × 470 kΩ = 1.88 MΩ** — SMD `4703` (1%, 4‑digit code `470×10³`), a series string near the mains input.
+- **Rup = 4 × 470 kΩ = 1.88 MΩ** in series with a **22 Ω fusible** on the N side → **Rup_total ≈ 1,880,022 Ω** — SMD `4703` (1%, 4‑digit code `470×10³`).
 - **Rdown = 1 kΩ** — marked `018`, measured 1.00 kΩ (ohm mode, 2 kΩ range).
-- **Divider ratio = (Rup + Rdown)/Rdown = 1881.**
-- V2P at 230 V ≈ 230 × 1000/1,881,000 ≈ **122 mV RMS** — within the HLW8012 V2 range.
+- **Divider ratio = (Rup_total + Rdown)/Rdown ≈ 1881** (the 22 Ω is 0.001 % of Rup — negligible).
+- V2P at 230 V ≈ 230 × 1000/1,881,022 ≈ **122 mV RMS** — within the HLW8012 V2 range.
 
-> The nearby **~22 Ω through‑hole flameproof resistor** (bands red‑red‑black‑gold, measured 21.2 Ω) is the **SMPS mains inrush / fusible safety resistor** in the supply input — **not** part of the metering divider. Ignore it for calibration (22 Ω vs 1.88 MΩ is negligible even if in series).
+> The **~22 Ω through‑hole flameproof resistor** (bands red‑red‑black‑gold, measured 21.2 Ω) is a **shared mains inrush / fusible safety resistor**: it sits between the true **N terminal** and the board's internal post‑fuse node, from which **both the SMPS input and this voltage divider** are fed. So it **is** in series in the divider's return to N — but at 22 Ω vs 1.88 MΩ it does not affect calibration.
 
 ### Initial multipliers (xoseperez/hlw8012 formula — V_REF = 2.43, F_OSC = 3.579 MHz)
 Driver setup equivalent: `setResistors(current = 0.002, v_upstream = 1.88e6, v_downstream = 1000)`.

--- a/doc/QBKG_HLW8012_power_metering_RE.md
+++ b/doc/QBKG_HLW8012_power_metering_RE.md
@@ -1,0 +1,161 @@
+# QBKG11LM / QBKG12LM — HLW8012 power‑metering reverse engineering
+
+Reverse‑engineering of the power‑measurement path on the Aqara **QBKG11LM (1‑gang)** /
+**QBKG12LM (2‑gang)** with‑neutral wall switches, for adding energy metering to the
+**hellozigbee** firmware (grafalex82/hellozigbee) running on the on‑board **NXP JN5169**.
+
+- **CPU board:** `LM15-LNS-PA-A-T0` (LUMI) — JN5169 MCU, buttons, LEDs, antenna + PA.
+- **Metering chip:** **HLW8012** single‑phase energy‑metering IC, on the **power board**.
+- grafalex identified the HLW8012 in doc part26 but did **not** reverse‑engineer its wiring —
+  this document fills that gap.
+- Goal: expose **active power (W)**, **RMS current (A)** / **RMS voltage (V)**, and
+  **cumulative energy (kWh)** over Zigbee.
+
+> ⚠️ **NON‑ISOLATED BOARD.** The common/GND rail is tied to mains **Live** (confirmed: HLW8012
+> GND pin 5, the 2N7002 source, and TP11 are all the same net = L). The *entire* logic domain —
+> JN5169 included — floats at mains potential. Continuity tracing on a **dead** board is safe;
+> **never probe it powered.** Do calibration through the **isolated Zigbee link** (read values in
+> z2m against a reference meter on the load), or use an isolation transformer + differential probe.
+
+---
+
+## 1. HLW8012 (SOP‑8) — chip pinout
+
+```
+                       ┌────∪────┐
+   VDD  ── 1  ●────────┤         ├────────  8 ── SEL   (mode select, input; internal pull-down)
+   V1P  ── 2  ─────────┤         ├────────  7 ── CF1   (current/voltage pulse out)
+   V1N  ── 3  ─────────┤ HLW8012 ├────────  6 ── CF    (power/energy pulse out)
+   V2P  ── 4  ─────────┤         ├────────  5 ── GND
+                       └─────────┘
+```
+| Pin | Name | Function |
+|---|---|---|
+| 1 | VDD | supply — **5 V** on this board |
+| 2 | V1P | current sense + (across shunt) — mains side |
+| 3 | V1N | current sense − (across shunt) — mains side |
+| 4 | V2P | voltage sense (from divider off L) — mains side |
+| 5 | GND | ground — **tied to mains L** (non‑isolated) |
+| 6 | **CF** | pulse freq ∝ **active power (W)**; pulse **count = energy (kWh)** |
+| 7 | **CF1** | pulse freq ∝ **RMS current** (SEL=0) or **RMS voltage** (SEL=1) |
+| 8 | **SEL** | selects CF1 output type |
+
+---
+
+## 2. Signal chains — HLW8012 → JN5169
+
+The chip runs at **5 V**, the JN5169 at **3.3 V**, so every MCU‑facing line is level‑shifted.
+
+### CF (power / energy) — HLW8012 pin 6
+```
+CF (pin6, 5V) ─ TP8 ─ 10kΩ (103) ─┬─ TP9 (tap ≈3.0V) ─ JP2 pin 8 ─ JN5169 pin 31 = DIO8 (PC1)
+                                   └─ 15kΩ (18C) ─ TP11 (GND/L)
+```
+- Resistive divider: 5 V × 15/(10+15) = **3.0 V** at the tap (TP9).
+- Lands on **DIO8 = hardware Pulse Counter 1 (PC1)**.
+
+### CF1 (current / voltage) — HLW8012 pin 7
+```
+CF1 (pin7, 5V) ─ TP6 ─ 10kΩ (103) ─┬─ TP7 (tap ≈3.0V) ─ JP1 pin 5 ─ JN5169 pin 17 = DIO1 (PC0)
+                                    └─ 15kΩ (18C) ─ TP11 (GND/L)
+```
+- Same 10k/15k divider → 3.0 V tap (TP7).
+- Lands on **DIO1 = hardware Pulse Counter 0 (PC0)**.
+
+### SEL (mode select) — HLW8012 pin 8
+```
+JN5169 pin 32 = DIO9 ─ JP1 pin 7 ─ TP2 ─ 2N7002 (N-MOSFET, marked "702") ─ SEL (pin8)
+                                          gate=control, drain=SEL, source=common/L
+```
+- Level‑shifted **up** (3.3 V MCU → 5 V SEL) through a **2N7002** — **inverting**.
+- Lands on **DIO9** (plain GPIO output).
+- SEL logic polarity is inverted by the FET → **determine empirically** (drive DIO9, watch whether
+  CF1 reports current vs voltage).
+
+---
+
+## 3. Final pin map
+
+| HLW8012 | signal | power‑board TPs | level shift | JP connector | JN5169 pin | JN5169 DIO | peripheral |
+|---|---|---|---|---|---|---|---|
+| pin 6 | **CF** (power/energy) | TP8 → tap **TP9** | 10k/15k divider → 3.0 V | **JP2 pin 8** | **31** | **DIO8** | **PC1** (pulse counter 1) |
+| pin 7 | **CF1** (current/voltage) | TP6 → tap **TP7** | 10k/15k divider → 3.0 V | **JP1 pin 5** | **17** | **DIO1** | **PC0** (pulse counter 0) |
+| pin 8 | **SEL** (mode select) | **TP2** | 2N7002, inverting up‑shift | **JP1 pin 7** | **32** | **DIO9** | GPIO out (inverted) |
+
+**Directions (JN5169):** DIO8 = input (PC1), DIO1 = input (PC0), DIO9 = output.
+
+---
+
+## 4. Connectors (board‑to‑board)
+
+Two 8‑pin (4×2) headers, dot = pin 1, **zig‑zag** numbering (`1 2 / 3 4 / 5 6 / 7 8`).
+Metering uses **JP1** and **JP2** (JP1 carries most of it).
+
+**JP1 (partially mapped):**
+| pin | net |
+|---|---|
+| 1 | VDD (5 V) → HLW8012 pin 1 |
+| 5 | CF1 tap (TP7) → DIO1 |
+| 7 | SEL (TP2, via 2N7002) → DIO9 |
+| 8 | GND (= TP11, tied to L) |
+| 2,3,4,6 | not mapped (VDD/GND/relay control/other) |
+
+**JP2 (partially mapped):**
+| pin | net |
+|---|---|
+| 8 | CF tap (TP9) → DIO8 |
+| others | not mapped |
+
+---
+
+## 5. Power‑board test points (as used here)
+
+| TP | net |
+|---|---|
+| TP2 | SEL control (2N7002 gate side) → JP1 pin 7 |
+| TP6 | HLW8012 CF1 (pin 7, raw 5 V) |
+| TP7 | CF1 divider **tap** (3.0 V) → JP1 pin 5 |
+| TP8 | HLW8012 CF (pin 6, raw 5 V) |
+| TP9 | CF divider **tap** (3.0 V) → JP2 pin 8 |
+| TP11 | **GND / common — tied to mains L** (reference for both dividers, 2N7002 source, HLW8012 GND) |
+
+---
+
+## 6. Driver implementation notes (JN5169 / hellozigbee)
+
+- **Use the hardware pulse counters** (not GPIO edge interrupts): CF → **PC1** (DIO8), CF1 → **PC0**
+  (DIO1). The JN516x SDK provides pulse‑counter APIs (`vAHI_PulseCounterConfigure`, etc.). This is
+  robust at high CF frequencies (high power) where interrupt‑driven counting could miss edges.
+  - **Energy (kWh):** accumulate the **CF** pulse count over time.
+  - **Power (W):** CF **frequency** — read PC1 over a fixed window, or use the period between pulses.
+  - **Current/Voltage:** CF1 frequency (PC0), with **SEL** toggled to select which.
+  - Note DIO8 also has `TIM0CK_GT` and DIO9 has `TIM0CAP` — timer capture is an alternative for
+    precise period measurement if needed.
+- **SEL (DIO9):** GPIO output, **inverted** through the 2N7002. Drive it, alternate current/voltage
+  reads, settle time per the HLW8012 datasheet before reading CF1. Confirm polarity empirically.
+- **Level shift:** CF/CF1 arrive already divided to ~3.0 V (safe for 3.3 V DIO). The divider changes
+  amplitude only — **pulse frequency is unchanged**, so it does **not** affect counting/calibration.
+- **Calibration (TBD):** HLW8012 output frequencies depend on the **current shunt** (V1P/V1N) and the
+  **voltage divider** (V2P) on the power board. Read those component values off the board, or
+  calibrate against a **known resistive load + reference meter**. Port the maths/constants from an
+  existing driver:
+  - `xoseperez/hlw8012` (Arduino), ESPHome `hlw8012`, or Tasmota.
+- **Zigbee exposure:** add standard clusters so z2m renders it automatically:
+  - `haElectricalMeasurement` (0x0B04): `activePower` (W), `rmsCurrent` (A), `rmsVoltage` (V).
+  - `seMetering` (0x0702): `instantaneousDemand` (W), `currentSummationDelivered` (kWh).
+  - Slots into hellozigbee's existing cluster/endpoint + attribute‑reporting infrastructure.
+
+---
+
+## 7. TODO
+
+- [ ] Read/measure shunt + voltage‑divider values → calibration constants.
+- [ ] Determine SEL (DIO9) active polarity empirically (2N7002 inverts).
+- [ ] Implement PC0/PC1 pulse‑counter driver + SEL toggling.
+- [ ] Add `haElectricalMeasurement` / `seMetering` clusters + reporting.
+- [ ] Coordinate/PR upstream (grafalex82/hellozigbee — it's an open "current and power sensor" TODO).
+
+## References
+- HLW8012 datasheet (Hiliwei Tech).
+- JN5169 datasheet Rev 1.4 (NXP) — pin config Fig 3 / Table 2.
+- hellozigbee doc part26 (QBKG12LM support) — identifies the HLW8012, notes it was not RE'd.

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -10,6 +10,9 @@ extern "C"
 #include "EndpointManager.h"
 #include "LEDTask.h"
 #include "DumpFunctions.h"
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+#include "EnergyMeterTask.h"
+#endif
 
 BasicClusterEndpoint::BasicClusterEndpoint()
 {
@@ -71,6 +74,22 @@ void BasicClusterEndpoint::registerDeviceTemperatureCluster()
         DBG_vPrintf(TRUE, "BasicClusterEndpoint::registerDeviceTemperatureCluster(): Failed to create Device Temperature Configuration Cluster instance. Status=%d\n", status);
 }
 
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+void BasicClusterEndpoint::registerElectricalMeasurementCluster()
+{
+    // Create an instance of an electrical measurement cluster as a server
+    teZCL_Status status = eCLD_ElectricalMeasurementCreateElectricalMeasurement(
+        &clusterInstances.sElectricalMeasurementServer,
+        TRUE,
+        &sCLD_ElectricalMeasurement,
+        &sElectricalMeasurementServerCluster,
+        &au8ElectricalMeasurementAttributeControlBits[0]);
+
+    if(status != E_ZCL_SUCCESS)
+        DBG_vPrintf(TRUE, "BasicClusterEndpoint::registerElectricalMeasurementCluster(): Failed to create Electrical Measurement Cluster instance. Status=%d\n", status);
+}
+#endif
+
 void BasicClusterEndpoint::registerEndpoint()
 {
     // Fill in end point details
@@ -94,6 +113,9 @@ void BasicClusterEndpoint::init()
     registerIdentifyCluster();
     registerOtaCluster();
     registerDeviceTemperatureCluster();
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    registerElectricalMeasurementCluster();
+#endif
     registerEndpoint();
 
     // Fill Basic cluster attributes
@@ -102,6 +124,11 @@ void BasicClusterEndpoint::init()
     memcpy(sBasicServerCluster.au8DateCode, CLD_BAS_DATE_STR, CLD_BAS_DATE_SIZE);
     memcpy(sBasicServerCluster.au8SWBuildID, CLD_BAS_SW_BUILD_STR, CLD_BAS_SW_BUILD_SIZE);
     sBasicServerCluster.eGenericDeviceType = E_CLD_BAS_GENERIC_DEVICE_TYPE_WALL_SWITCH;
+
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    // Bit 0 = active measurement (AC)
+    sElectricalMeasurementServerCluster.u32MeasurementType = 1;
+#endif
 
     // Initialize OTA
     otaHandlers.initOTA(getEndpointId());
@@ -205,6 +232,12 @@ teZCL_CommandStatus BasicClusterEndpoint::handleReadAttribute(tsZCL_CallBackEven
         case GENERAL_CLUSTER_ID_DEVICE_TEMPERATURE_CONFIGURATION:
             readDeviceTemperature();
             break;
+
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+        case MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT:
+            readElectricalMeasurement();
+            break;
+#endif
     }
 
     return E_ZCL_CMDS_SUCCESS;
@@ -231,3 +264,22 @@ void BasicClusterEndpoint::readDeviceTemperature()
     // Disable the ADC
     vAHI_AdcDisable();
 }
+
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+void BasicClusterEndpoint::readElectricalMeasurement()
+{
+    // Phase 1 (pulse plumbing): the attributes carry RAW HLW8012 pulse
+    // frequencies in 0.1 Hz units, not electrical units yet.
+    // ActivePower <- CF frequency, RMSVoltage <- CF1 frequency.
+    // Calibrated conversion comes in the next phase.
+    uint16 cfFreqDHz = EnergyMeterTask::getInstance()->getCfFreqDHz();
+    uint16 cf1FreqDHz = EnergyMeterTask::getInstance()->getCf1FreqDHz();
+
+    sElectricalMeasurementServerCluster.i16ActivePower = (cfFreqDHz > 32767) ? 32767 : cfFreqDHz;
+    sElectricalMeasurementServerCluster.u16RMSVoltage = cf1FreqDHz;
+    sElectricalMeasurementServerCluster.u16RMSCurrent = 0;
+
+    DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement raw read: CF=%d dHz, CF1=%d dHz\n",
+                cfFreqDHz, cf1FreqDHz);
+}
+#endif

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -128,6 +128,11 @@ void BasicClusterEndpoint::init()
 #ifdef CLD_ELECTRICAL_MEASUREMENT
     // Bit 0 = active measurement (AC)
     sElectricalMeasurementServerCluster.u32MeasurementType = 1;
+    // ActivePower is in W, RMSVoltage in 0.1 V
+    sElectricalMeasurementServerCluster.u16ACPowerMultiplier = 1;
+    sElectricalMeasurementServerCluster.u16ACPowerDivisor = 1;
+    sElectricalMeasurementServerCluster.u16ACVoltageMultiplier = 1;
+    sElectricalMeasurementServerCluster.u16ACVoltageDivisor = 10;
 #endif
 
     // Initialize OTA
@@ -268,22 +273,22 @@ void BasicClusterEndpoint::readDeviceTemperature()
 #ifdef CLD_ELECTRICAL_MEASUREMENT
 void BasicClusterEndpoint::readElectricalMeasurement()
 {
-    // Phase 1 (pulse plumbing): the attributes carry RAW HLW8012 pulse
-    // frequencies in 0.1 Hz units, not electrical units yet.
-    // ActivePower <- CF frequency, RMSVoltage <- CF1 frequency.
-    // Calibrated conversion comes in the next phase.
     uint16 cfFreqDHz = EnergyMeterTask::getInstance()->getCfFreqDHz();
     uint16 cf1FreqDHz = EnergyMeterTask::getInstance()->getCf1FreqDHz();
 
-    sElectricalMeasurementServerCluster.i16ActivePower = (cfFreqDHz > 32767) ? 32767 : cfFreqDHz;
-    sElectricalMeasurementServerCluster.u16RMSVoltage = cf1FreqDHz;
+    // CF frequency -> active power (W); CF1 in voltage mode (SEL low) -> RMS voltage (0.1 V)
+    uint32 watts = (uint32)cfFreqDHz * METERING_W_PER_DHZ_E5 / 100000;
+    sElectricalMeasurementServerCluster.i16ActivePower = (watts > 32767) ? 32767 : watts;
+    sElectricalMeasurementServerCluster.u16RMSVoltage = (uint32)cf1FreqDHz * METERING_DV_PER_DHZ_E5 / 100000;
     sElectricalMeasurementServerCluster.u16RMSCurrent = 0;
 
     // Cumulative pulse counts for integrative calibration (0xFF00/0xFF01)
     sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = EnergyMeterTask::getInstance()->getCfTotal();
     sElectricalMeasurementServerCluster.u32NonActivePower = EnergyMeterTask::getInstance()->getCf1Total();
 
-    DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement raw read: CF=%d dHz, CF1=%d dHz\n",
+    DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement read: %d W, %d dV (CF=%d dHz, CF1=%d dHz)\n",
+                sElectricalMeasurementServerCluster.i16ActivePower,
+                sElectricalMeasurementServerCluster.u16RMSVoltage,
                 cfFreqDHz, cf1FreqDHz);
 }
 #endif

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -74,6 +74,23 @@ void BasicClusterEndpoint::registerDeviceTemperatureCluster()
         DBG_vPrintf(TRUE, "BasicClusterEndpoint::registerDeviceTemperatureCluster(): Failed to create Device Temperature Configuration Cluster instance. Status=%d\n", status);
 }
 
+#ifdef CLD_SM
+void BasicClusterEndpoint::registerSimpleMeteringCluster()
+{
+    // Create an instance of a simple metering cluster as a server
+    teZCL_Status status = eSE_SMCreate(getEndpointId(),
+                                       TRUE,
+                                       &au8SimpleMeteringServerAttributeControlBits[0],
+                                       &clusterInstances.sSimpleMeteringServer,
+                                       &sCLD_SimpleMetering,
+                                       &sSimpleMeteringCustomDataStruct,
+                                       &sSimpleMeteringServerCluster);
+
+    if(status != E_ZCL_SUCCESS)
+        DBG_vPrintf(TRUE, "BasicClusterEndpoint::registerSimpleMeteringCluster(): Failed to create Simple Metering Cluster instance. Status=%d\n", status);
+}
+#endif
+
 #ifdef CLD_ELECTRICAL_MEASUREMENT
 void BasicClusterEndpoint::registerElectricalMeasurementCluster()
 {
@@ -116,6 +133,9 @@ void BasicClusterEndpoint::init()
 #ifdef CLD_ELECTRICAL_MEASUREMENT
     registerElectricalMeasurementCluster();
 #endif
+#ifdef CLD_SM
+    registerSimpleMeteringCluster();
+#endif
     registerEndpoint();
 
     // Fill Basic cluster attributes
@@ -135,6 +155,21 @@ void BasicClusterEndpoint::init()
     sElectricalMeasurementServerCluster.u16ACVoltageDivisor = 10;
     sElectricalMeasurementServerCluster.u16ACCurrentMultiplier = 1;
     sElectricalMeasurementServerCluster.u16ACCurentDivisor = 1000;  // (sic - SDK field name typo)
+#endif
+
+#ifdef CLD_SM
+    // CurrentSummationDelivered is in Wh: kWh = value * multiplier / divisor
+    sSimpleMeteringServerCluster.eUnitOfMeasure = 0;                // kWh
+    sSimpleMeteringServerCluster.u24Multiplier = 1;
+    sSimpleMeteringServerCluster.u24Divisor = 1000;
+    sSimpleMeteringServerCluster.u8SummationFormatting = 0xBB;      // suppress zeros, 7 int + 3 frac digits
+    sSimpleMeteringServerCluster.u8MeterStatus = 0;
+    sSimpleMeteringServerCluster.eMeteringDeviceType = 0;           // electric metering
+#endif
+
+#ifdef SUPPORTS_POWER_METERING
+    // From now on the meter task pushes fresh values into the cluster structs
+    EnergyMeterTask::getInstance()->setMeteringEndpoint(this);
 #endif
 
     // Initialize OTA
@@ -242,7 +277,12 @@ teZCL_CommandStatus BasicClusterEndpoint::handleReadAttribute(tsZCL_CallBackEven
 
 #ifdef CLD_ELECTRICAL_MEASUREMENT
         case MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT:
-            readElectricalMeasurement();
+#ifdef CLD_SM
+        case SE_CLUSTER_ID_SIMPLE_METERING:
+#endif
+            // Values are pushed every sampling window; refresh once more so a
+            // read straddling the window boundary gets the newest data
+            updateMeteringAttributes();
             break;
 #endif
     }
@@ -273,7 +313,7 @@ void BasicClusterEndpoint::readDeviceTemperature()
 }
 
 #ifdef CLD_ELECTRICAL_MEASUREMENT
-void BasicClusterEndpoint::readElectricalMeasurement()
+void BasicClusterEndpoint::updateMeteringAttributes()
 {
     uint16 cfFreqDHz = EnergyMeterTask::getInstance()->getCfFreqDHz();
     uint16 voltageFreqDHz = EnergyMeterTask::getInstance()->getVoltageFreqDHz();
@@ -287,13 +327,13 @@ void BasicClusterEndpoint::readElectricalMeasurement()
     sElectricalMeasurementServerCluster.u16RMSCurrent = (mA > 65535) ? 65535 : mA;
 
     // Cumulative pulse counts for integrative calibration (0xFF00/0xFF01)
-    sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = EnergyMeterTask::getInstance()->getCfTotal();
+    sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = (uint32)EnergyMeterTask::getInstance()->getCfTotal();
     sElectricalMeasurementServerCluster.u32NonActivePower = EnergyMeterTask::getInstance()->getCf1Total();
 
-    DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement read: %d W, %d dV, %d mA (CF=%d dHz)\n",
-                sElectricalMeasurementServerCluster.i16ActivePower,
-                sElectricalMeasurementServerCluster.u16RMSVoltage,
-                sElectricalMeasurementServerCluster.u16RMSCurrent,
-                cfFreqDHz);
+#ifdef CLD_SM
+    // Lifetime energy in Wh: pulses * (W-per-dHz / 1e5) J/pulse * 10 / 3600
+    sSimpleMeteringServerCluster.u48CurrentSummationDelivered =
+        EnergyMeterTask::getInstance()->getCfTotal() * METERING_W_PER_DHZ_E5 / 36000000;
+#endif
 }
 #endif

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "EndpointManager.h"
 #include "LEDTask.h"
 #include "DumpFunctions.h"
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
 #include "EnergyMeterTask.h"
 #endif
 
@@ -74,7 +74,7 @@ void BasicClusterEndpoint::registerDeviceTemperatureCluster()
         DBG_vPrintf(TRUE, "BasicClusterEndpoint::registerDeviceTemperatureCluster(): Failed to create Device Temperature Configuration Cluster instance. Status=%d\n", status);
 }
 
-#ifdef CLD_SM
+#ifdef SUPPORTS_POWER_METERING
 void BasicClusterEndpoint::registerSimpleMeteringCluster()
 {
     // Create an instance of a simple metering cluster as a server
@@ -91,7 +91,7 @@ void BasicClusterEndpoint::registerSimpleMeteringCluster()
 }
 #endif
 
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
 void BasicClusterEndpoint::registerElectricalMeasurementCluster()
 {
     // Create an instance of an electrical measurement cluster as a server
@@ -130,10 +130,8 @@ void BasicClusterEndpoint::init()
     registerIdentifyCluster();
     registerOtaCluster();
     registerDeviceTemperatureCluster();
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     registerElectricalMeasurementCluster();
-#endif
-#ifdef CLD_SM
     registerSimpleMeteringCluster();
 #endif
     registerEndpoint();
@@ -145,7 +143,7 @@ void BasicClusterEndpoint::init()
     memcpy(sBasicServerCluster.au8SWBuildID, CLD_BAS_SW_BUILD_STR, CLD_BAS_SW_BUILD_SIZE);
     sBasicServerCluster.eGenericDeviceType = E_CLD_BAS_GENERIC_DEVICE_TYPE_WALL_SWITCH;
 
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     // Bit 0 = active measurement (AC)
     sElectricalMeasurementServerCluster.u32MeasurementType = 1;
     // ActivePower is in W, RMSVoltage in 0.1 V, RMSCurrent in mA
@@ -155,9 +153,7 @@ void BasicClusterEndpoint::init()
     sElectricalMeasurementServerCluster.u16ACVoltageDivisor = 10;
     sElectricalMeasurementServerCluster.u16ACCurrentMultiplier = 1;
     sElectricalMeasurementServerCluster.u16ACCurentDivisor = 1000;  // (sic - SDK field name typo)
-#endif
 
-#ifdef CLD_SM
     // CurrentSummationDelivered is in Wh: kWh = value * multiplier / divisor
     sSimpleMeteringServerCluster.eUnitOfMeasure = 0;                // kWh
     sSimpleMeteringServerCluster.u24Multiplier = 1;
@@ -165,21 +161,15 @@ void BasicClusterEndpoint::init()
     sSimpleMeteringServerCluster.u8SummationFormatting = 0xBB;      // suppress zeros, 7 int + 3 frac digits
     sSimpleMeteringServerCluster.u8MeterStatus = 0;
     sSimpleMeteringServerCluster.eMeteringDeviceType = 0;           // electric metering
-#endif
 
-#ifdef CLD_ELECTRICAL_MEASUREMENT
     // The RP flag in the attribute definition table (vendored cluster files) makes the
     // reporting engine include these attributes; the per-instance control bits below are
     // what the configure-reporting command handler checks (E_ZCL_ACF_RP) - both are needed
     eZCL_SetReportableFlag(getEndpointId(), MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT, TRUE, FALSE, E_CLD_ELECTMEAS_ATTR_ID_ACTIVE_POWER);
     eZCL_SetReportableFlag(getEndpointId(), MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT, TRUE, FALSE, E_CLD_ELECTMEAS_ATTR_ID_RMS_VOLATGE);  // (sic - SDK enum typo)
     eZCL_SetReportableFlag(getEndpointId(), MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT, TRUE, FALSE, E_CLD_ELECTMEAS_ATTR_ID_RMS_CURRENT);
-#endif
-#ifdef CLD_SM
     eZCL_SetReportableFlag(getEndpointId(), SE_CLUSTER_ID_SIMPLE_METERING, TRUE, FALSE, E_CLD_SM_ATTR_ID_CURRENT_SUMMATION_DELIVERED);
-#endif
 
-#ifdef SUPPORTS_POWER_METERING
     // From now on the meter task pushes fresh values into the cluster structs
     EnergyMeterTask::getInstance()->setMeteringEndpoint(this);
 #endif
@@ -287,11 +277,9 @@ teZCL_CommandStatus BasicClusterEndpoint::handleReadAttribute(tsZCL_CallBackEven
             readDeviceTemperature();
             break;
 
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
         case MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT:
-#ifdef CLD_SM
         case SE_CLUSTER_ID_SIMPLE_METERING:
-#endif
             // Values are pushed every sampling window; refresh once more so a
             // read straddling the window boundary gets the newest data
             updateMeteringAttributes();
@@ -324,28 +312,20 @@ void BasicClusterEndpoint::readDeviceTemperature()
     vAHI_AdcDisable();
 }
 
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
 void BasicClusterEndpoint::updateMeteringAttributes()
 {
-    uint16 cfFreqDHz = EnergyMeterTask::getInstance()->getCfFreqDHz();
-    uint16 voltageFreqDHz = EnergyMeterTask::getInstance()->getVoltageFreqDHz();
-    uint16 currentFreqDHz = EnergyMeterTask::getInstance()->getCurrentFreqDHz();
+    EnergyMeterTask * meter = EnergyMeterTask::getInstance();
 
     // CF -> active power (W); CF1 -> RMS voltage (0.1 V) / RMS current (mA) per SEL mode
-    uint32 watts = (uint32)cfFreqDHz * METERING_W_PER_DHZ_E5 / 100000;
-    uint32 mA = (uint32)currentFreqDHz * METERING_MA_PER_DHZ_E5 / 100000;
-    sElectricalMeasurementServerCluster.i16ActivePower = (watts > 32767) ? 32767 : watts;
-    sElectricalMeasurementServerCluster.u16RMSVoltage = (uint32)voltageFreqDHz * METERING_DV_PER_DHZ_E5 / 100000;
-    sElectricalMeasurementServerCluster.u16RMSCurrent = (mA > 65535) ? 65535 : mA;
+    sElectricalMeasurementServerCluster.i16ActivePower = meter->getActivePowerW();
+    sElectricalMeasurementServerCluster.u16RMSVoltage = meter->getVoltageDV();
+    sElectricalMeasurementServerCluster.u16RMSCurrent = meter->getCurrentMA();
 
     // Cumulative pulse counts for integrative calibration (0xFF00/0xFF01)
-    sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = (uint32)EnergyMeterTask::getInstance()->getCfTotal();
-    sElectricalMeasurementServerCluster.u32NonActivePower = EnergyMeterTask::getInstance()->getCf1Total();
+    sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = (uint32)meter->getCfTotal();
+    sElectricalMeasurementServerCluster.u32NonActivePower = meter->getCf1Total();
 
-#ifdef CLD_SM
-    // Lifetime energy in Wh: pulses * (W-per-dHz / 1e5) J/pulse * 10 / 3600
-    sSimpleMeteringServerCluster.u48CurrentSummationDelivered =
-        EnergyMeterTask::getInstance()->getCfTotal() * METERING_W_PER_DHZ_E5 / 36000000;
-#endif
+    sSimpleMeteringServerCluster.u48CurrentSummationDelivered = meter->getEnergyWh();
 }
 #endif

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -128,11 +128,13 @@ void BasicClusterEndpoint::init()
 #ifdef CLD_ELECTRICAL_MEASUREMENT
     // Bit 0 = active measurement (AC)
     sElectricalMeasurementServerCluster.u32MeasurementType = 1;
-    // ActivePower is in W, RMSVoltage in 0.1 V
+    // ActivePower is in W, RMSVoltage in 0.1 V, RMSCurrent in mA
     sElectricalMeasurementServerCluster.u16ACPowerMultiplier = 1;
     sElectricalMeasurementServerCluster.u16ACPowerDivisor = 1;
     sElectricalMeasurementServerCluster.u16ACVoltageMultiplier = 1;
     sElectricalMeasurementServerCluster.u16ACVoltageDivisor = 10;
+    sElectricalMeasurementServerCluster.u16ACCurrentMultiplier = 1;
+    sElectricalMeasurementServerCluster.u16ACCurentDivisor = 1000;  // (sic - SDK field name typo)
 #endif
 
     // Initialize OTA
@@ -274,21 +276,24 @@ void BasicClusterEndpoint::readDeviceTemperature()
 void BasicClusterEndpoint::readElectricalMeasurement()
 {
     uint16 cfFreqDHz = EnergyMeterTask::getInstance()->getCfFreqDHz();
-    uint16 cf1FreqDHz = EnergyMeterTask::getInstance()->getCf1FreqDHz();
+    uint16 voltageFreqDHz = EnergyMeterTask::getInstance()->getVoltageFreqDHz();
+    uint16 currentFreqDHz = EnergyMeterTask::getInstance()->getCurrentFreqDHz();
 
-    // CF frequency -> active power (W); CF1 in voltage mode (SEL low) -> RMS voltage (0.1 V)
+    // CF -> active power (W); CF1 -> RMS voltage (0.1 V) / RMS current (mA) per SEL mode
     uint32 watts = (uint32)cfFreqDHz * METERING_W_PER_DHZ_E5 / 100000;
+    uint32 mA = (uint32)currentFreqDHz * METERING_MA_PER_DHZ_E5 / 100000;
     sElectricalMeasurementServerCluster.i16ActivePower = (watts > 32767) ? 32767 : watts;
-    sElectricalMeasurementServerCluster.u16RMSVoltage = (uint32)cf1FreqDHz * METERING_DV_PER_DHZ_E5 / 100000;
-    sElectricalMeasurementServerCluster.u16RMSCurrent = 0;
+    sElectricalMeasurementServerCluster.u16RMSVoltage = (uint32)voltageFreqDHz * METERING_DV_PER_DHZ_E5 / 100000;
+    sElectricalMeasurementServerCluster.u16RMSCurrent = (mA > 65535) ? 65535 : mA;
 
     // Cumulative pulse counts for integrative calibration (0xFF00/0xFF01)
     sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = EnergyMeterTask::getInstance()->getCfTotal();
     sElectricalMeasurementServerCluster.u32NonActivePower = EnergyMeterTask::getInstance()->getCf1Total();
 
-    DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement read: %d W, %d dV (CF=%d dHz, CF1=%d dHz)\n",
+    DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement read: %d W, %d dV, %d mA (CF=%d dHz)\n",
                 sElectricalMeasurementServerCluster.i16ActivePower,
                 sElectricalMeasurementServerCluster.u16RMSVoltage,
-                cfFreqDHz, cf1FreqDHz);
+                sElectricalMeasurementServerCluster.u16RMSCurrent,
+                cfFreqDHz);
 }
 #endif

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -167,6 +167,18 @@ void BasicClusterEndpoint::init()
     sSimpleMeteringServerCluster.eMeteringDeviceType = 0;           // electric metering
 #endif
 
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    // The RP flag in the attribute definition table (vendored cluster files) makes the
+    // reporting engine include these attributes; the per-instance control bits below are
+    // what the configure-reporting command handler checks (E_ZCL_ACF_RP) - both are needed
+    eZCL_SetReportableFlag(getEndpointId(), MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT, TRUE, FALSE, E_CLD_ELECTMEAS_ATTR_ID_ACTIVE_POWER);
+    eZCL_SetReportableFlag(getEndpointId(), MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT, TRUE, FALSE, E_CLD_ELECTMEAS_ATTR_ID_RMS_VOLATGE);  // (sic - SDK enum typo)
+    eZCL_SetReportableFlag(getEndpointId(), MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT, TRUE, FALSE, E_CLD_ELECTMEAS_ATTR_ID_RMS_CURRENT);
+#endif
+#ifdef CLD_SM
+    eZCL_SetReportableFlag(getEndpointId(), SE_CLUSTER_ID_SIMPLE_METERING, TRUE, FALSE, E_CLD_SM_ATTR_ID_CURRENT_SUMMATION_DELIVERED);
+#endif
+
 #ifdef SUPPORTS_POWER_METERING
     // From now on the meter task pushes fresh values into the cluster structs
     EnergyMeterTask::getInstance()->setMeteringEndpoint(this);

--- a/src/BasicClusterEndpoint.cpp
+++ b/src/BasicClusterEndpoint.cpp
@@ -279,6 +279,10 @@ void BasicClusterEndpoint::readElectricalMeasurement()
     sElectricalMeasurementServerCluster.u16RMSVoltage = cf1FreqDHz;
     sElectricalMeasurementServerCluster.u16RMSCurrent = 0;
 
+    // Cumulative pulse counts for integrative calibration (0xFF00/0xFF01)
+    sElectricalMeasurementServerCluster.u32ManSpecificApparentPower = EnergyMeterTask::getInstance()->getCfTotal();
+    sElectricalMeasurementServerCluster.u32NonActivePower = EnergyMeterTask::getInstance()->getCf1Total();
+
     DBG_vPrintf(TRUE, "BasicClusterEndpoint: Electrical measurement raw read: CF=%d dHz, CF1=%d dHz\n",
                 cfFreqDHz, cf1FreqDHz);
 }

--- a/src/BasicClusterEndpoint.h
+++ b/src/BasicClusterEndpoint.h
@@ -13,6 +13,9 @@ extern "C"
 #ifdef CLD_ELECTRICAL_MEASUREMENT
     #include "ElectricalMeasurement.h"
 #endif
+#ifdef CLD_SM
+    #include "SimpleMetering.h"
+#endif
 }
 
 // List of cluster instances (descriptor objects) that are included into an Endpoint
@@ -34,6 +37,11 @@ struct BasicClusterInstances
     // Boards with a metering IC report power/voltage/current over the Electrical Measurement cluster
     tsZCL_ClusterInstance sElectricalMeasurementServer;
 #endif
+
+#ifdef CLD_SM
+    // ... and cumulative energy over the Simple Metering cluster
+    tsZCL_ClusterInstance sSimpleMeteringServer;
+#endif
 } __attribute__ ((aligned(4)));
 
 class BasicClusterEndpoint : public Endpoint
@@ -50,6 +58,10 @@ class BasicClusterEndpoint : public Endpoint
     tsCLD_DeviceTemperatureConfiguration sDeviceTemperatureServerCluster;
 #ifdef CLD_ELECTRICAL_MEASUREMENT
     tsCLD_ElectricalMeasurement sElectricalMeasurementServerCluster;
+#endif
+#ifdef CLD_SM
+    tsCLD_SimpleMetering sSimpleMeteringServerCluster;
+    tsSM_CustomStruct sSimpleMeteringCustomDataStruct;
 #endif
     tsCLD_AS_Ota sOTAClientCluster;
     tsOTA_Common sOTACustomDataStruct;
@@ -69,6 +81,9 @@ protected:
 #ifdef CLD_ELECTRICAL_MEASUREMENT
     virtual void registerElectricalMeasurementCluster();
 #endif
+#ifdef CLD_SM
+    virtual void registerSimpleMeteringCluster();
+#endif
     virtual void registerEndpoint();
 
     virtual void handleClusterUpdate(tsZCL_CallBackEvent *psEvent);
@@ -81,8 +96,12 @@ protected:
     void handleOTAClusterUpdate(tsZCL_CallBackEvent *psEvent);
 
     void readDeviceTemperature();
+
+public:
 #ifdef CLD_ELECTRICAL_MEASUREMENT
-    void readElectricalMeasurement();
+    // Called by EnergyMeterTask every sampling window - keeps the cluster
+    // structs fresh for both explicit reads and the attribute reporting engine
+    void updateMeteringAttributes();
 #endif
 };
 

--- a/src/BasicClusterEndpoint.h
+++ b/src/BasicClusterEndpoint.h
@@ -10,6 +10,9 @@ extern "C"
     #include "Basic.h"
     #include "Identify.h"
     #include "DeviceTemperatureConfiguration.h"
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    #include "ElectricalMeasurement.h"
+#endif
 }
 
 // List of cluster instances (descriptor objects) that are included into an Endpoint
@@ -26,6 +29,11 @@ struct BasicClusterInstances
 
     // The device will report its temperature over the Device Temperature Configuration cluster
     tsZCL_ClusterInstance sDeviceTemperatureServer;
+
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    // Boards with a metering IC report power/voltage/current over the Electrical Measurement cluster
+    tsZCL_ClusterInstance sElectricalMeasurementServer;
+#endif
 } __attribute__ ((aligned(4)));
 
 class BasicClusterEndpoint : public Endpoint
@@ -40,6 +48,9 @@ class BasicClusterEndpoint : public Endpoint
     tsCLD_Identify sIdentifyServerCluster;
     tsCLD_IdentifyCustomDataStructure sIdentifyClusterData;
     tsCLD_DeviceTemperatureConfiguration sDeviceTemperatureServerCluster;
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    tsCLD_ElectricalMeasurement sElectricalMeasurementServerCluster;
+#endif
     tsCLD_AS_Ota sOTAClientCluster;
     tsOTA_Common sOTACustomDataStruct;
 
@@ -55,6 +66,9 @@ protected:
     virtual void registerIdentifyCluster();
     virtual void registerOtaCluster();
     virtual void registerDeviceTemperatureCluster();
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    virtual void registerElectricalMeasurementCluster();
+#endif
     virtual void registerEndpoint();
 
     virtual void handleClusterUpdate(tsZCL_CallBackEvent *psEvent);
@@ -67,6 +81,9 @@ protected:
     void handleOTAClusterUpdate(tsZCL_CallBackEvent *psEvent);
 
     void readDeviceTemperature();
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+    void readElectricalMeasurement();
+#endif
 };
 
 #endif // BASICCLUSTERENDPOINT_H

--- a/src/BasicClusterEndpoint.h
+++ b/src/BasicClusterEndpoint.h
@@ -10,10 +10,10 @@ extern "C"
     #include "Basic.h"
     #include "Identify.h"
     #include "DeviceTemperatureConfiguration.h"
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     #include "ElectricalMeasurement.h"
 #endif
-#ifdef CLD_SM
+#ifdef SUPPORTS_POWER_METERING
     #include "SimpleMetering.h"
 #endif
 }
@@ -33,12 +33,12 @@ struct BasicClusterInstances
     // The device will report its temperature over the Device Temperature Configuration cluster
     tsZCL_ClusterInstance sDeviceTemperatureServer;
 
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     // Boards with a metering IC report power/voltage/current over the Electrical Measurement cluster
     tsZCL_ClusterInstance sElectricalMeasurementServer;
 #endif
 
-#ifdef CLD_SM
+#ifdef SUPPORTS_POWER_METERING
     // ... and cumulative energy over the Simple Metering cluster
     tsZCL_ClusterInstance sSimpleMeteringServer;
 #endif
@@ -56,10 +56,10 @@ class BasicClusterEndpoint : public Endpoint
     tsCLD_Identify sIdentifyServerCluster;
     tsCLD_IdentifyCustomDataStructure sIdentifyClusterData;
     tsCLD_DeviceTemperatureConfiguration sDeviceTemperatureServerCluster;
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     tsCLD_ElectricalMeasurement sElectricalMeasurementServerCluster;
 #endif
-#ifdef CLD_SM
+#ifdef SUPPORTS_POWER_METERING
     tsCLD_SimpleMetering sSimpleMeteringServerCluster;
     tsSM_CustomStruct sSimpleMeteringCustomDataStruct;
 #endif
@@ -78,10 +78,10 @@ protected:
     virtual void registerIdentifyCluster();
     virtual void registerOtaCluster();
     virtual void registerDeviceTemperatureCluster();
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     virtual void registerElectricalMeasurementCluster();
 #endif
-#ifdef CLD_SM
+#ifdef SUPPORTS_POWER_METERING
     virtual void registerSimpleMeteringCluster();
 #endif
     virtual void registerEndpoint();
@@ -98,7 +98,7 @@ protected:
     void readDeviceTemperature();
 
 public:
-#ifdef CLD_ELECTRICAL_MEASUREMENT
+#ifdef SUPPORTS_POWER_METERING
     // Called by EnergyMeterTask every sampling window - keeps the cluster
     // structs fresh for both explicit reads and the attribute reporting engine
     void updateMeteringAttributes();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,8 +69,10 @@ set(ZIGBEE_SRC
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/BasicClientCommands.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/BasicCommandHandler.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/DeviceTemperatureConfiguration.c
-        # Patched copy (reportable-attribute flags) - see the header of the file
+        # Patched copies (reportable-attribute flags) - see the headers of the files
         ${CMAKE_CURRENT_SOURCE_DIR}/ElectricalMeasurement.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/SimpleMetering.c
+        ${SDK_PREFIX}/Components/ZCL/Clusters/SmartEnergy/Source/SimpleMeteringCommandHandler.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/Groups.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/GroupsClientCommands.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/GroupsCommandHandler.c
@@ -115,6 +117,7 @@ target_include_directories(ZigBee PRIVATE
 	${SDK_PREFIX}/Components/MicroSpecific/Include
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source
         ${SDK_PREFIX}/Components/ZCL/Clusters/OTA/Include
+        ${SDK_PREFIX}/Components/ZCL/Clusters/SmartEnergy/Source
 
         ${SDK_PREFIX}/Components/ZCIF/Source
 
@@ -153,6 +156,7 @@ include_directories(
     ${SDK_PREFIX}/Components/ZCL/Clusters/General/Include
     ${SDK_PREFIX}/Components/ZCL/Clusters/OTA/Include
     ${SDK_PREFIX}/Components/ZCL/Clusters/MeasurementAndSensing/Include
+    ${SDK_PREFIX}/Components/ZCL/Clusters/SmartEnergy/Include
     ${SDK_PREFIX}/Components/ZCL/Devices/ZLO/Include
     ${SDK_PREFIX}/Components/ZigbeeCommon/Include
     ${SDK_PREFIX}/Components/ZPSAPL/Include

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ set(ZIGBEE_SRC
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/BasicClientCommands.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/BasicCommandHandler.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/DeviceTemperatureConfiguration.c
+        ${SDK_PREFIX}/Components/ZCL/Clusters/MeasurementAndSensing/Source/ElectricalMeasurement.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/Groups.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/GroupsClientCommands.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/GroupsCommandHandler.c
@@ -188,6 +189,7 @@ set(SOURCES
         LEDPair.cpp
         RelayHandler.cpp
         RelayTask.cpp
+        EnergyMeterTask.cpp
         ButtonHandler.cpp
         PollTask.cpp
         DumpFunctions.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,8 @@ set(ZIGBEE_SRC
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/BasicClientCommands.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/BasicCommandHandler.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/DeviceTemperatureConfiguration.c
-        ${SDK_PREFIX}/Components/ZCL/Clusters/MeasurementAndSensing/Source/ElectricalMeasurement.c
+        # Patched copy (reportable-attribute flags) - see the header of the file
+        ${CMAKE_CURRENT_SOURCE_DIR}/ElectricalMeasurement.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/Groups.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/GroupsClientCommands.c
         ${SDK_PREFIX}/Components/ZCL/Clusters/General/Source/GroupsCommandHandler.c

--- a/src/ElectricalMeasurement.c
+++ b/src/ElectricalMeasurement.c
@@ -1,0 +1,300 @@
+/*
+ * PATCHED copy of sdk/Components/ZCL/Clusters/MeasurementAndSensing/Source/ElectricalMeasurement.c
+ * (JN-SW-4170). Delta: E_ZCL_AF_RP added to RMSVoltage, RMSCurrent and ActivePower so the
+ * attributes are reportable - the ZCL reporting engine and eZCL_ReportAttribute() both refuse
+ * attributes without the RP flag, and coordinators (z2m) configure reporting for these.
+ */
+/*****************************************************************************
+ *
+ * MODULE:             Electrical Measurement Cluster
+ *
+ * COMPONENT:          ElectricalMeasurement.c
+ *
+ * AUTHOR:             Lee Mitchell
+ *
+ * DESCRIPTION:        Electrical Measurement cluster definition
+ *
+ * $HeadURL: https://www.collabnet.nxp.com/svn/lprf_sware/Projects/Components/ZCL/Branches/Zigbee_3_0/Clusters/General/Source/ElectricalMeasurement.c $
+ *
+ * $Revision: 70975 $
+ *
+ * $LastChangedBy: nxp57621 $
+ *
+ * $LastChangedDate: 2015-07-06 12:33:15 +0530 (Mon, 06 Jul 2015) $
+ *
+ * $Id: ElectricalMeasurement.c 70975 2015-07-06 07:03:15Z nxp57621 $
+ *
+ *****************************************************************************
+ *
+ * This software is owned by NXP B.V. and/or its supplier and is protected
+ * under applicable copyright laws. All rights are reserved. We grant You,
+ * and any third parties, a license to use this software solely and
+ * exclusively on NXP products [NXP Microcontrollers such as JN5168, JN5164,
+ * JN5161, JN5148, JN5142, JN5139].
+ * You, and any third parties must reproduce the copyright and warranty notice
+ * and any other legend of ownership on each  copy or partial copy of the software.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Copyright NXP B.V. 2012. All rights reserved
+ *
+ ****************************************************************************/
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <jendefs.h>
+#include "zcl.h"
+#include "ElectricalMeasurement.h"
+
+
+#ifdef CLD_ELECTRICAL_MEASUREMENT
+/****************************************************************************/
+/***        Macro Definitions                                             ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Type Definitions                                              ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Local Function Prototypes                                     ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Exported Variables                                            ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Local Variables                                               ***/
+/****************************************************************************/
+const tsZCL_AttributeDefinition asCLD_ElectricalMeasurementClusterAttributeDefinitions[] = {
+#ifdef ELECTRICAL_MEASUREMENT_SERVER
+        {E_CLD_ELECTMEAS_ATTR_ID_MEASUREMENT_TYPE,                      E_ZCL_AF_RD,                    E_ZCL_BMAP32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32MeasurementType),      0},   /* Mandatory */
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_FREQUENCY
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_FREQUENCY,                          E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACFrequency),          0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_RMS_VOLTAGE
+        {E_CLD_ELECTMEAS_ATTR_ID_RMS_VOLATGE,                           (E_ZCL_AF_RD|E_ZCL_AF_RP),                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16RMSVoltage),           0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_RMS_CURRENT
+        {E_CLD_ELECTMEAS_ATTR_ID_RMS_CURRENT,                           (E_ZCL_AF_RD|E_ZCL_AF_RP),                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16RMSCurrent),           0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_ACTIVE_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_ACTIVE_POWER,                          (E_ZCL_AF_RD|E_ZCL_AF_RP),                    E_ZCL_INT16,     (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->i16ActivePower),          0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_REACTIVE_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_REACTIVE_POWER,                        E_ZCL_AF_RD,                    E_ZCL_INT16,     (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->i16ReactivePower),        0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_APPARENT_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_APPARENT_POWER,                        E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ApparentPower),        0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_POWER_FACTOR
+        {E_CLD_ELECTMEAS_ATTR_ID_POWER_FACTOR,                          E_ZCL_AF_RD,                    E_ZCL_INT8,      (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->i8PowerFactor),           0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_VOLTAGE_MULTIPLIER
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_VOLTAGE_MULTIPLIER,                 E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACVoltageMultiplier),  0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_VOLTAGE_DIVISOR,                    E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACVoltageDivisor),     0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_CURRENT_MULTIPLIER
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_CURRENT_MULTIPLIER,                 E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACCurrentMultiplier),  0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_CURRENT_DIVISOR
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_CURRENT_DIVISOR,                    E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACCurentDivisor),      0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_POWER_MULTIPLIER
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_POWER_MULTIPLIER,                   E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACPowerMultiplier),    0},   /* Optional */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_AC_POWER_DIVISOR
+        {E_CLD_ELECTMEAS_ATTR_ID_AC_POWER_DIVISOR,                      E_ZCL_AF_RD,                    E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ACPowerDivisor),       0},   /* Optional */
+    #endif
+    
+    /*Manufacturer Specific Attributes*/
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_APPARENT_POWER   
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_APPARENT_POWER,               (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32ManSpecificApparentPower),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_NON_ACTIVE_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_NON_ACTIVE_POWER,             (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32NonActivePower),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_FNDMTL_REACTIVE_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_FNDMTL_REACTIVE_POWER,        (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_INT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->i32FundamentalReactivePower),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_FNDMTL_APPARENT_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_FNDMTL_APPARENT_POWER,        (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32FundamentalApparentPower),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_FNDMTL_POWER_FACTOR
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_FNDMTL_POWER_FACTOR,          (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16FundamentalPowerFactor),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_NON_FNDMTL_APPARENT_POWER
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_NON_FNDMTL_APPARENT_POWER,    (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32NonFundamentalApparentPower),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_TOTAL_HARMONIC_DISTORTION
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_TOTAL_HARMONIC_DISTORTION,    (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32TotalHarmonicDistortion),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_VBIAS
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_VBIAS,                        (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT32,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u32VBias),       0},   /* Manu Specific */
+    #endif
+
+    #ifdef CLD_ELECTMEAS_ATTR_MAN_SPEC_DIVISOR
+        {E_CLD_ELECTMEAS_ATTR_ID_MAN_SPEC_DIVISOR,                      (E_ZCL_AF_RD|E_ZCL_AF_MS),      E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ManSpecDivisor),       0},   /* Manu Specific */
+    #endif
+
+#endif    
+        {E_CLD_GLOBAL_ATTR_ID_CLUSTER_REVISION,                         (E_ZCL_AF_RD|E_ZCL_AF_GA),      E_ZCL_UINT16,    (uint32)(&((tsCLD_ElectricalMeasurement*)(0))->u16ClusterRevision),      0},   /* Mandatory  */
+
+    };
+
+tsZCL_ClusterDefinition sCLD_ElectricalMeasurement = {
+        MEASUREMENT_AND_SENSING_CLUSTER_ID_ELECTRICAL_MEASUREMENT,
+        FALSE,
+        E_ZCL_SECURITY_NETWORK,
+        (sizeof(asCLD_ElectricalMeasurementClusterAttributeDefinitions) / sizeof(tsZCL_AttributeDefinition)),
+        (tsZCL_AttributeDefinition*)asCLD_ElectricalMeasurementClusterAttributeDefinitions,
+        NULL
+};
+
+uint8 au8ElectricalMeasurementAttributeControlBits[(sizeof(asCLD_ElectricalMeasurementClusterAttributeDefinitions) / sizeof(tsZCL_AttributeDefinition))];
+/****************************************************************************/
+/***        Exported Functions                                            ***/
+/****************************************************************************/
+/****************************************************************************
+ **
+ ** NAME:       eCLD_ElectricalMeasurementCreateElectricalMeasurement
+ **
+ ** DESCRIPTION:
+ ** Creates a temperature measurement cluster
+ **
+ ** PARAMETERS:                 Name                        Usage
+ ** tsZCL_ClusterInstance    *psClusterInstance             Cluster structure
+ **
+ ** RETURN:
+ ** teZCL_Status
+ **
+ ****************************************************************************/
+PUBLIC  teZCL_Status eCLD_ElectricalMeasurementCreateElectricalMeasurement(
+                tsZCL_ClusterInstance              *psClusterInstance,
+                bool_t                              bIsServer,
+                tsZCL_ClusterDefinition            *psClusterDefinition,
+                void                               *pvEndPointSharedStructPtr,
+                uint8                              *pu8AttributeControlBits)
+{
+    #ifdef STRICT_PARAM_CHECK 
+        /* Parameter check */
+        if((psClusterInstance==NULL) ||
+           (psClusterDefinition==NULL))
+        {
+            return E_ZCL_ERR_PARAMETER_NULL;
+        }
+    #endif
+
+    /* Create an instance of a temperature measurement cluster */
+    vZCL_InitializeClusterInstance(
+                   psClusterInstance, 
+                   bIsServer,
+                   psClusterDefinition,
+                   pvEndPointSharedStructPtr,
+                   pu8AttributeControlBits,
+                   NULL,
+                   NULL);
+
+        if(pvEndPointSharedStructPtr != NULL)
+        {
+#ifdef ELECTRICAL_MEASUREMENT_SERVER            
+            /* Initializing these values to invalid as ZCL spec does not mention the defualt */ 
+            #ifdef CLD_ELECTMEAS_ATTR_AC_FREQUENCY
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACFrequency = 0xFFFF;
+            #endif
+            
+            #ifdef CLD_ELECTMEAS_ATTR_RMS_VOLTAGE
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16RMSVoltage = 0xFFFF;
+            #endif
+            
+            #ifdef CLD_ELECTMEAS_ATTR_RMS_CURRENT
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16RMSCurrent = 0xFFFF;
+            #endif
+            
+            #ifdef CLD_ELECTMEAS_ATTR_ACTIVE_POWER
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->i16ActivePower = 0xFFFF;
+            #endif
+
+            #ifdef CLD_ELECTMEAS_ATTR_REACTIVE_POWER
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->i16ReactivePower = 0xFFFF;
+            #endif
+            
+            #ifdef CLD_ELECTMEAS_ATTR_APPARENT_POWER
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ApparentPower = 0xFFFF;
+            #endif
+            
+            #ifdef CLD_ELECTMEAS_ATTR_AC_VOLTAGE_MULTIPLIER
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACVoltageMultiplier = 0x0001;
+            #endif
+            
+            #ifdef CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACVoltageDivisor = 0x0001;
+            #endif
+    
+            #ifdef CLD_ELECTMEAS_ATTR_AC_CURRENT_MULTIPLIER
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACCurrentMultiplier = 0x0001;
+            #endif
+    
+            #ifdef CLD_ELECTMEAS_ATTR_AC_CURRENT_DIVISOR
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACCurentDivisor = 0x0001;
+            #endif
+    
+            #ifdef CLD_ELECTMEAS_ATTR_AC_POWER_MULTIPLIER
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACPowerMultiplier = 0x0001;
+            #endif
+    
+            #ifdef CLD_ELECTMEAS_ATTR_AC_POWER_DIVISOR
+                ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ACPowerDivisor = 0x0001;
+            #endif
+#endif            
+            ((tsCLD_ElectricalMeasurement*)pvEndPointSharedStructPtr)->u16ClusterRevision = CLD_ELECTMEAS_CLUSTER_REVISION;
+        }
+
+    return E_ZCL_SUCCESS;
+
+}
+
+/****************************************************************************/
+/***        Local Functions                                               ***/
+/****************************************************************************/
+
+#endif/* CLD_ELECTRICAL_MEASUREMENT */
+/****************************************************************************/
+/***        END OF FILE                                                   ***/
+/****************************************************************************/
+

--- a/src/EnergyMeterTask.cpp
+++ b/src/EnergyMeterTask.cpp
@@ -1,0 +1,71 @@
+#include "zcl_options.h"
+
+#ifdef SUPPORTS_POWER_METERING
+
+#include "EnergyMeterTask.h"
+
+extern "C"
+{
+    #include "AppHardwareApi.h"
+    #include "dbg.h"
+}
+
+// Must stay well below the ~30 s wrap time of a 16-bit counter at the
+// maximum expected pulse frequency (~2.2 kHz on CF1 at 16 A)
+static const uint32 SAMPLE_PERIOD_MS = 1000;
+
+EnergyMeterTask::EnergyMeterTask()
+{
+    // Drive SEL low for a deterministic CF1 mode. The signal reaches the
+    // HLW8012 inverted through a 2N7002; actual polarity is resolved later
+    vAHI_DioSetDirection(0, METERING_SEL_MASK);
+    vAHI_DioSetOutput(0, METERING_SEL_MASK);
+
+    // CF/CF1 pins are the pulse counters' default inputs already, just make
+    // sure they are inputs
+    vAHI_DioSetDirection(METERING_CF_MASK | METERING_CF1_MASK, 0);
+
+    // Rising edge, debounce off (debounce would cap counting at 1.2-3.7 kHz),
+    // counters kept separate (both channels needed), no interrupts
+    bAHI_PulseCounterConfigure(E_AHI_PC_1, 0, 0, E_AHI_PC_COMBINE_OFF, FALSE);
+    bAHI_PulseCounterConfigure(E_AHI_PC_0, 0, 0, E_AHI_PC_COMBINE_OFF, FALSE);
+    bAHI_StartPulseCounter(E_AHI_PC_1);
+    bAHI_StartPulseCounter(E_AHI_PC_0);
+
+    // Baseline the counts after start: bAHI_StartPulseCounter() may bump the
+    // count by one even without a pulse
+    bAHI_Read16BitCounter(E_AHI_PC_1, &prevCfCount);
+    bAHI_Read16BitCounter(E_AHI_PC_0, &prevCf1Count);
+    cfFreqDHz = 0;
+    cf1FreqDHz = 0;
+
+    PeriodicTask::init(SAMPLE_PERIOD_MS);
+    startTimer(SAMPLE_PERIOD_MS);
+}
+
+EnergyMeterTask * EnergyMeterTask::getInstance()
+{
+    static EnergyMeterTask instance;
+    return &instance;
+}
+
+void EnergyMeterTask::timerCallback()
+{
+    uint16 cfCount, cf1Count;
+    bAHI_Read16BitCounter(E_AHI_PC_1, &cfCount);
+    bAHI_Read16BitCounter(E_AHI_PC_0, &cf1Count);
+
+    uint16 cfDelta = (uint16)(cfCount - prevCfCount);
+    uint16 cf1Delta = (uint16)(cf1Count - prevCf1Count);
+    prevCfCount = cfCount;
+    prevCf1Count = cf1Count;
+
+    // pulses over a 1 s window -> 0.1 Hz units, clamped against uint16 overflow
+    cfFreqDHz = (cfDelta > 6553) ? 65535 : cfDelta * 10;
+    cf1FreqDHz = (cf1Delta > 6553) ? 65535 : cf1Delta * 10;
+
+    DBG_vPrintf(TRUE, "EnergyMeterTask: CF=%d.%d Hz, CF1=%d.%d Hz\n",
+                cfFreqDHz / 10, cfFreqDHz % 10, cf1FreqDHz / 10, cf1FreqDHz % 10);
+}
+
+#endif // SUPPORTS_POWER_METERING

--- a/src/EnergyMeterTask.cpp
+++ b/src/EnergyMeterTask.cpp
@@ -23,6 +23,20 @@ static const uint8 TIMEBASE_PRESCALE = 14;
 static const uint32 TIMEBASE_DHZ_MUL = 78125;
 static const uint32 TIMEBASE_DHZ_DIV = 8;
 
+// Conversion constants, scaled by 1e5: value = freq_dHz * K / 100000.
+// Power: calibrated 2026-08-02 against an inline power meter (1910 W at
+// 424.41 Hz CF over a 3 min pulse-count integration) -> 4.5004 W/Hz,
+// +8.8 % over the datasheet-nominal 4.138 (shunt below its marked 2 mOhm).
+// Voltage: calibrated against a multimeter at the load terminals under load
+// (235.5 V read vs 225.3 V displayed -> +4.53 % over datasheet-nominal).
+// Current: derived, not directly measured - all HLW8012 channels share Vref
+// and the shunt, so Kc = Kp/Kv (+4.05 % over nominal; PF cross-check 0.966).
+// Constants are specimen-calibrated on a QBKG11LM; QBKG11LM and QBKG12LM
+// share the same board, so they serve as defaults for both.
+static const uint32 METERING_W_PER_DHZ_E5 = 45004;
+static const uint32 METERING_DV_PER_DHZ_E5 = 34176;
+static const uint32 METERING_MA_PER_DHZ_E5 = 75357;
+
 // SEL alternates CF1 between voltage and current mode every N sampling
 // windows; the window straddling the toggle is discarded (mode change +
 // HLW8012 settle), leaving N-1 valid windows per dwell
@@ -41,10 +55,6 @@ EnergyMeterTask::EnergyMeterTask()
     // HLW8012 inverted through a 2N7002; actual polarity is resolved later
     vAHI_DioSetDirection(0, METERING_SEL_MASK);
     vAHI_DioSetOutput(0, METERING_SEL_MASK);
-
-    // CF/CF1 pins are the pulse counters' default inputs already, just make
-    // sure they are inputs
-    vAHI_DioSetDirection(METERING_CF_MASK | METERING_CF1_MASK, 0);
 
     // Rising edge, debounce off (debounce would cap counting at 1.2-3.7 kHz),
     // counters kept separate (both channels needed), no interrupts
@@ -96,6 +106,30 @@ static uint16 freqDHz(uint16 pulses, uint16 ticks)
 
     uint64 f = (uint64)pulses * TIMEBASE_DHZ_MUL / ((uint32)ticks * TIMEBASE_DHZ_DIV);
     return (f > 65535) ? 65535 : (uint16)f;
+}
+
+
+uint16 EnergyMeterTask::getActivePowerW() const
+{
+    uint32 watts = (uint32)cfFreqDHz * METERING_W_PER_DHZ_E5 / 100000;
+    return (watts > 32767) ? 32767 : watts;    // ZCL ActivePower is int16
+}
+
+uint16 EnergyMeterTask::getVoltageDV() const
+{
+    return (uint32)voltageFreqDHz * METERING_DV_PER_DHZ_E5 / 100000;
+}
+
+uint16 EnergyMeterTask::getCurrentMA() const
+{
+    uint32 mA = (uint32)currentFreqDHz * METERING_MA_PER_DHZ_E5 / 100000;
+    return (mA > 65535) ? 65535 : mA;
+}
+
+uint64 EnergyMeterTask::getEnergyWh() const
+{
+    // Each CF pulse is a fixed energy quantum: Wh = pulses * (W/Hz) / 3600
+    return cfTotal * METERING_W_PER_DHZ_E5 / 36000000;
 }
 
 void EnergyMeterTask::timerCallback()

--- a/src/EnergyMeterTask.cpp
+++ b/src/EnergyMeterTask.cpp
@@ -14,6 +14,14 @@ extern "C"
 // maximum expected pulse frequency (~2.2 kHz on CF1 at 16 A)
 static const uint32 SAMPLE_PERIOD_MS = 1000;
 
+// Timer 0 free-runs as the sampling timebase: 16 MHz / 2^14 = 976.5625 Hz.
+// The ZTIMER 1 s callback jitters when the main loop is busy (radio storms),
+// so the window length is measured, never assumed. 16-bit wrap = 67 s.
+static const uint8 TIMEBASE_PRESCALE = 14;
+// freq[dHz] = pulses * 976.5625 * 10 / ticks = pulses * 78125 / (ticks * 8)
+static const uint32 TIMEBASE_DHZ_MUL = 78125;
+static const uint32 TIMEBASE_DHZ_DIV = 8;
+
 EnergyMeterTask::EnergyMeterTask()
 {
     // Drive SEL low for a deterministic CF1 mode. The signal reaches the
@@ -32,12 +40,21 @@ EnergyMeterTask::EnergyMeterTask()
     bAHI_StartPulseCounter(E_AHI_PC_1);
     bAHI_StartPulseCounter(E_AHI_PC_0);
 
+    // Timebase timer: no interrupts, no output - and no DIO takeover, its
+    // pins overlap CF (DIO8), SEL (DIO9) and the button (DIO10)
+    vAHI_TimerDIOControl(E_AHI_TIMER_0, FALSE);
+    vAHI_TimerEnable(E_AHI_TIMER_0, TIMEBASE_PRESCALE, FALSE, FALSE, FALSE);
+    vAHI_TimerStartRepeat(E_AHI_TIMER_0, 0x0000, 0xFFFF);
+
     // Baseline the counts after start: bAHI_StartPulseCounter() may bump the
     // count by one even without a pulse
     bAHI_Read16BitCounter(E_AHI_PC_1, &prevCfCount);
     bAHI_Read16BitCounter(E_AHI_PC_0, &prevCf1Count);
+    prevTimebaseTicks = u16AHI_TimerReadCount(E_AHI_TIMER_0);
     cfFreqDHz = 0;
     cf1FreqDHz = 0;
+    cfTotal = 0;
+    cf1Total = 0;
 
     PeriodicTask::init(SAMPLE_PERIOD_MS);
     startTimer(SAMPLE_PERIOD_MS);
@@ -49,23 +66,37 @@ EnergyMeterTask * EnergyMeterTask::getInstance()
     return &instance;
 }
 
+static uint16 freqDHz(uint16 pulses, uint16 ticks)
+{
+    if(ticks == 0)
+        return 0;
+
+    uint64 f = (uint64)pulses * TIMEBASE_DHZ_MUL / ((uint32)ticks * TIMEBASE_DHZ_DIV);
+    return (f > 65535) ? 65535 : (uint16)f;
+}
+
 void EnergyMeterTask::timerCallback()
 {
     uint16 cfCount, cf1Count;
     bAHI_Read16BitCounter(E_AHI_PC_1, &cfCount);
     bAHI_Read16BitCounter(E_AHI_PC_0, &cf1Count);
+    uint16 nowTicks = u16AHI_TimerReadCount(E_AHI_TIMER_0);
 
     uint16 cfDelta = (uint16)(cfCount - prevCfCount);
     uint16 cf1Delta = (uint16)(cf1Count - prevCf1Count);
+    uint16 tickDelta = (uint16)(nowTicks - prevTimebaseTicks);
     prevCfCount = cfCount;
     prevCf1Count = cf1Count;
+    prevTimebaseTicks = nowTicks;
 
-    // pulses over a 1 s window -> 0.1 Hz units, clamped against uint16 overflow
-    cfFreqDHz = (cfDelta > 6553) ? 65535 : cfDelta * 10;
-    cf1FreqDHz = (cf1Delta > 6553) ? 65535 : cf1Delta * 10;
+    cfTotal += cfDelta;
+    cf1Total += cf1Delta;
 
-    DBG_vPrintf(TRUE, "EnergyMeterTask: CF=%d.%d Hz, CF1=%d.%d Hz\n",
-                cfFreqDHz / 10, cfFreqDHz % 10, cf1FreqDHz / 10, cf1FreqDHz % 10);
+    cfFreqDHz = freqDHz(cfDelta, tickDelta);
+    cf1FreqDHz = freqDHz(cf1Delta, tickDelta);
+
+    DBG_vPrintf(TRUE, "EnergyMeterTask: CF=%d.%d Hz, CF1=%d.%d Hz (window %d ticks)\n",
+                cfFreqDHz / 10, cfFreqDHz % 10, cf1FreqDHz / 10, cf1FreqDHz % 10, tickDelta);
 }
 
 #endif // SUPPORTS_POWER_METERING

--- a/src/EnergyMeterTask.cpp
+++ b/src/EnergyMeterTask.cpp
@@ -22,6 +22,11 @@ static const uint8 TIMEBASE_PRESCALE = 14;
 static const uint32 TIMEBASE_DHZ_MUL = 78125;
 static const uint32 TIMEBASE_DHZ_DIV = 8;
 
+// SEL alternates CF1 between voltage and current mode every N sampling
+// windows; the window straddling the toggle is discarded (mode change +
+// HLW8012 settle), leaving N-1 valid windows per dwell
+static const uint8 SEL_DWELL_TICKS = 5;
+
 EnergyMeterTask::EnergyMeterTask()
 {
     // Drive SEL low for a deterministic CF1 mode. The signal reaches the
@@ -52,9 +57,13 @@ EnergyMeterTask::EnergyMeterTask()
     bAHI_Read16BitCounter(E_AHI_PC_0, &prevCf1Count);
     prevTimebaseTicks = u16AHI_TimerReadCount(E_AHI_TIMER_0);
     cfFreqDHz = 0;
-    cf1FreqDHz = 0;
+    voltageFreqDHz = 0;
+    currentFreqDHz = 0;
     cfTotal = 0;
     cf1Total = 0;
+    selCurrentMode = 0;         // constructor drove SEL low = voltage mode
+    modeTicks = 0;
+    transitionWindow = false;
 
     PeriodicTask::init(SAMPLE_PERIOD_MS);
     startTimer(SAMPLE_PERIOD_MS);
@@ -93,10 +102,32 @@ void EnergyMeterTask::timerCallback()
     cf1Total += cf1Delta;
 
     cfFreqDHz = freqDHz(cfDelta, tickDelta);
-    cf1FreqDHz = freqDHz(cf1Delta, tickDelta);
 
-    DBG_vPrintf(TRUE, "EnergyMeterTask: CF=%d.%d Hz, CF1=%d.%d Hz (window %d ticks)\n",
-                cfFreqDHz / 10, cfFreqDHz % 10, cf1FreqDHz / 10, cf1FreqDHz % 10, tickDelta);
+    // Attribute the CF1 window to the mode that was active throughout it
+    uint16 cf1FreqDHz = freqDHz(cf1Delta, tickDelta);
+    if(transitionWindow)
+        transitionWindow = false;
+    else if(selCurrentMode)
+        currentFreqDHz = cf1FreqDHz;
+    else
+        voltageFreqDHz = cf1FreqDHz;
+
+    // Alternate SEL between voltage and current measurement
+    if(++modeTicks >= SEL_DWELL_TICKS)
+    {
+        selCurrentMode ^= 1;
+        // DIO9 low = voltage mode, high = current mode (2N7002 inverts on its way to SEL)
+        if(selCurrentMode)
+            vAHI_DioSetOutput(METERING_SEL_MASK, 0);
+        else
+            vAHI_DioSetOutput(0, METERING_SEL_MASK);
+        modeTicks = 0;
+        transitionWindow = true;
+    }
+
+    DBG_vPrintf(TRUE, "EnergyMeterTask: CF=%d.%d Hz, CF1=%d.%d Hz mode=%c (window %d ticks)\n",
+                cfFreqDHz / 10, cfFreqDHz % 10, cf1FreqDHz / 10, cf1FreqDHz % 10,
+                selCurrentMode ? 'I' : 'V', tickDelta);
 }
 
 #endif // SUPPORTS_POWER_METERING

--- a/src/EnergyMeterTask.cpp
+++ b/src/EnergyMeterTask.cpp
@@ -3,6 +3,7 @@
 #ifdef SUPPORTS_POWER_METERING
 
 #include "EnergyMeterTask.h"
+#include "BasicClusterEndpoint.h"
 
 extern "C"
 {
@@ -26,6 +27,13 @@ static const uint32 TIMEBASE_DHZ_DIV = 8;
 // windows; the window straddling the toggle is discarded (mode change +
 // HLW8012 settle), leaving N-1 valid windows per dwell
 static const uint8 SEL_DWELL_TICKS = 5;
+
+// Energy register persistence: save when this many pulses accumulated since
+// the last save (~0.1 kWh at the calibrated 4.5 J/pulse), or daily if any
+// unsaved energy exists. Keeps EEPROM wear negligible (>=5 years even at a
+// continuous 5 kWh/day) while bounding the power-cut loss to ~0.1 kWh.
+static const uint32 ENERGY_SAVE_PULSE_DELTA = 80000;
+static const uint32 ENERGY_SAVE_MAX_TICKS = 86400;
 
 EnergyMeterTask::EnergyMeterTask()
 {
@@ -59,11 +67,17 @@ EnergyMeterTask::EnergyMeterTask()
     cfFreqDHz = 0;
     voltageFreqDHz = 0;
     currentFreqDHz = 0;
-    cfTotal = 0;
     cf1Total = 0;
     selCurrentMode = 0;         // constructor drove SEL low = voltage mode
     modeTicks = 0;
     transitionWindow = false;
+
+    // Restore the lifetime energy register
+    persistedEnergyPulses.init((uint64)0, "Energy");
+    cfTotal = persistedEnergyPulses.getValue();
+    lastSavedPulses = cfTotal;
+    ticksSinceSave = 0;
+    meteringEndpoint = NULL;
 
     PeriodicTask::init(SAMPLE_PERIOD_MS);
     startTimer(SAMPLE_PERIOD_MS);
@@ -124,6 +138,22 @@ void EnergyMeterTask::timerCallback()
         modeTicks = 0;
         transitionWindow = true;
     }
+
+    // Wear-aware persistence of the energy register
+    ticksSinceSave++;
+    if((cfTotal - lastSavedPulses >= ENERGY_SAVE_PULSE_DELTA) ||
+       (cfTotal != lastSavedPulses && ticksSinceSave >= ENERGY_SAVE_MAX_TICKS))
+    {
+        persistedEnergyPulses.setValue(cfTotal);
+        lastSavedPulses = cfTotal;
+        ticksSinceSave = 0;
+    }
+
+    // Push fresh values into the ZCL cluster structs so both reads and the
+    // attribute reporting engine (which samples the structs directly) see
+    // current data
+    if(meteringEndpoint)
+        meteringEndpoint->updateMeteringAttributes();
 
     DBG_vPrintf(TRUE, "EnergyMeterTask: CF=%d.%d Hz, CF1=%d.%d Hz mode=%c (window %d ticks)\n",
                 cfFreqDHz / 10, cfFreqDHz % 10, cf1FreqDHz / 10, cf1FreqDHz % 10,

--- a/src/EnergyMeterTask.h
+++ b/src/EnergyMeterTask.h
@@ -2,6 +2,10 @@
 #define ENERGY_METER_TASK_H
 
 #include "PeriodicTask.h"
+#include "PersistedValue.h"
+#include "PdmIds.h"
+
+class BasicClusterEndpoint;
 
 // Acquires pulse frequencies from the on-board HLW8012 energy metering IC
 // using the JN516x hardware pulse counters (no remapping needed):
@@ -17,11 +21,17 @@ class EnergyMeterTask : public PeriodicTask
     uint16 cfFreqDHz;       // last CF frequency in 0.1 Hz units (active power)
     uint16 voltageFreqDHz;  // last CF1 frequency measured in voltage mode
     uint16 currentFreqDHz;  // last CF1 frequency measured in current mode
-    uint32 cfTotal;         // cumulative CF pulses since boot (energy register)
+    uint64 cfTotal;         // lifetime CF pulses (energy register, PDM-backed)
     uint32 cf1Total;        // cumulative CF1 pulses since boot (mode-mixed, diagnostic)
     uint8 selCurrentMode;   // SEL state: 0 = voltage, 1 = current
     uint8 modeTicks;        // sampling windows spent in the present mode
     bool transitionWindow;  // window straddling a SEL toggle - not attributable
+
+    PersistedValue<uint64, PDM_ID_ENERGY> persistedEnergyPulses;
+    uint64 lastSavedPulses;
+    uint32 ticksSinceSave;
+
+    BasicClusterEndpoint * meteringEndpoint;
 
 private:
     EnergyMeterTask();
@@ -29,10 +39,12 @@ private:
 public:
     static EnergyMeterTask * getInstance();
 
+    void setMeteringEndpoint(BasicClusterEndpoint * ep) { meteringEndpoint = ep; }
+
     uint16 getCfFreqDHz() const { return cfFreqDHz; }
     uint16 getVoltageFreqDHz() const { return voltageFreqDHz; }
     uint16 getCurrentFreqDHz() const { return currentFreqDHz; }
-    uint32 getCfTotal() const { return cfTotal; }
+    uint64 getCfTotal() const { return cfTotal; }
     uint32 getCf1Total() const { return cf1Total; }
 
 protected:

--- a/src/EnergyMeterTask.h
+++ b/src/EnergyMeterTask.h
@@ -41,11 +41,16 @@ public:
 
     void setMeteringEndpoint(BasicClusterEndpoint * ep) { meteringEndpoint = ep; }
 
+    // Raw acquisition values (calibration/diagnostic attributes)
     uint16 getCfFreqDHz() const { return cfFreqDHz; }
-    uint16 getVoltageFreqDHz() const { return voltageFreqDHz; }
-    uint16 getCurrentFreqDHz() const { return currentFreqDHz; }
     uint64 getCfTotal() const { return cfTotal; }
     uint32 getCf1Total() const { return cf1Total; }
+
+    // Calibrated electrical values (conversion constants live in the task)
+    uint16 getActivePowerW() const;
+    uint16 getVoltageDV() const;
+    uint16 getCurrentMA() const;
+    uint64 getEnergyWh() const;
 
 protected:
     virtual void timerCallback();

--- a/src/EnergyMeterTask.h
+++ b/src/EnergyMeterTask.h
@@ -13,8 +13,11 @@ class EnergyMeterTask : public PeriodicTask
 {
     uint16 prevCfCount;
     uint16 prevCf1Count;
+    uint16 prevTimebaseTicks;
     uint16 cfFreqDHz;   // last CF frequency in 0.1 Hz units
     uint16 cf1FreqDHz;  // last CF1 frequency in 0.1 Hz units
+    uint32 cfTotal;     // cumulative CF pulses since boot (energy register)
+    uint32 cf1Total;    // cumulative CF1 pulses since boot
 
 private:
     EnergyMeterTask();
@@ -24,6 +27,8 @@ public:
 
     uint16 getCfFreqDHz() const { return cfFreqDHz; }
     uint16 getCf1FreqDHz() const { return cf1FreqDHz; }
+    uint32 getCfTotal() const { return cfTotal; }
+    uint32 getCf1Total() const { return cf1Total; }
 
 protected:
     virtual void timerCallback();

--- a/src/EnergyMeterTask.h
+++ b/src/EnergyMeterTask.h
@@ -14,10 +14,14 @@ class EnergyMeterTask : public PeriodicTask
     uint16 prevCfCount;
     uint16 prevCf1Count;
     uint16 prevTimebaseTicks;
-    uint16 cfFreqDHz;   // last CF frequency in 0.1 Hz units
-    uint16 cf1FreqDHz;  // last CF1 frequency in 0.1 Hz units
-    uint32 cfTotal;     // cumulative CF pulses since boot (energy register)
-    uint32 cf1Total;    // cumulative CF1 pulses since boot
+    uint16 cfFreqDHz;       // last CF frequency in 0.1 Hz units (active power)
+    uint16 voltageFreqDHz;  // last CF1 frequency measured in voltage mode
+    uint16 currentFreqDHz;  // last CF1 frequency measured in current mode
+    uint32 cfTotal;         // cumulative CF pulses since boot (energy register)
+    uint32 cf1Total;        // cumulative CF1 pulses since boot (mode-mixed, diagnostic)
+    uint8 selCurrentMode;   // SEL state: 0 = voltage, 1 = current
+    uint8 modeTicks;        // sampling windows spent in the present mode
+    bool transitionWindow;  // window straddling a SEL toggle - not attributable
 
 private:
     EnergyMeterTask();
@@ -26,7 +30,8 @@ public:
     static EnergyMeterTask * getInstance();
 
     uint16 getCfFreqDHz() const { return cfFreqDHz; }
-    uint16 getCf1FreqDHz() const { return cf1FreqDHz; }
+    uint16 getVoltageFreqDHz() const { return voltageFreqDHz; }
+    uint16 getCurrentFreqDHz() const { return currentFreqDHz; }
     uint32 getCfTotal() const { return cfTotal; }
     uint32 getCf1Total() const { return cf1Total; }
 

--- a/src/EnergyMeterTask.h
+++ b/src/EnergyMeterTask.h
@@ -1,0 +1,32 @@
+#ifndef ENERGY_METER_TASK_H
+#define ENERGY_METER_TASK_H
+
+#include "PeriodicTask.h"
+
+// Acquires pulse frequencies from the on-board HLW8012 energy metering IC
+// using the JN516x hardware pulse counters (no remapping needed):
+// - CF  (active power pulses)                  -> DIO8 -> Pulse Counter 1
+// - CF1 (current or voltage pulses, SEL-muxed) -> DIO1 -> Pulse Counter 0
+// The counters run free; frequencies are derived from count deltas over the
+// sampling period, with uint16 wrap-around arithmetic absorbing overflow.
+class EnergyMeterTask : public PeriodicTask
+{
+    uint16 prevCfCount;
+    uint16 prevCf1Count;
+    uint16 cfFreqDHz;   // last CF frequency in 0.1 Hz units
+    uint16 cf1FreqDHz;  // last CF1 frequency in 0.1 Hz units
+
+private:
+    EnergyMeterTask();
+
+public:
+    static EnergyMeterTask * getInstance();
+
+    uint16 getCfFreqDHz() const { return cfFreqDHz; }
+    uint16 getCf1FreqDHz() const { return cf1FreqDHz; }
+
+protected:
+    virtual void timerCallback();
+};
+
+#endif // ENERGY_METER_TASK_H

--- a/src/HelloZigbee.zpscfg
+++ b/src/HelloZigbee.zpscfg
@@ -99,6 +99,7 @@
     <Clusters Name="OOSC" Id="0x0007"/>
     <Clusters Name="MultistateInput" Id="0x0012"/>
     <Clusters Name="DeviceTemperature" Id="0x0002"/>
+    <Clusters Name="ElectricalMeasurement" Id="0x0B04"/>
   </Profiles>
   <Coordinator Name="Coordinator" DiscoveryNeighbourTableSize="16" ActiveNeighbourTableSize="10" RouteDiscoveryTableSize="16" RoutingTableSize="16" BroadcastTransactionTableSize="9" RouteRecordTableSize="4" AddressMapTableSize="10" SecurityMaterialSets="2" MaxNumSimultaneousApsdeReq="5" MaxNumSimultaneousApsdeAckReq="3" MACMutexName="mutexMAC" ZPSMutexName="mutexZPS" FragmentationMaxNumSimulRx="0" FragmentationMaxNumSimulTx="0" DefaultEventMessageName="APP_vZpsEventHandler" MACDcfmIndMessage="zps_msgDcfmInd" MACTimeEventMessage="zps_msgTimeEvents" apsNonMemberRadius="2" apsDesignatedCoordinator="true" apsUseInsecureJoin="true" apsMaxWindowSize="8" apsInterframeDelay="10" APSDuplicateTableSize="8" apsSecurityTimeoutPeriod="1000" apsUseExtPANId="0x0000000000000000" SecurityEnabled="false" MACMlmeDcfmIndMessage="zps_msgMlmeDcfmInd" MACMcpsDcfmIndMessage="zps_msgMcpsDcfmInd" APSPersistenceTime="100" NumAPSMESimulCommands="4" StackProfile="2" InterPAN="false" GreenPowerSupport="false" NwkFcSaveCountBitShift="4" ApsFcSaveCountBitShift="4" MacTableSize="36" DefaultCallbackName="APP_vGenCallback" PermitJoiningTime="255" ChildTableSize="5">
     <Endpoints Id="0" Enabled="true" ApplicationDeviceId="0" ApplicationDeviceVersion="0" Profile="ZDP" Name="ZDO">
@@ -714,6 +715,7 @@
       <InputClusters Cluster="Default" RxAPDU="QBKG11LM->apduZCL" Discoverable="false"/>
       <InputClusters Cluster="Identify" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
       <InputClusters Cluster="DeviceTemperature" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
+      <InputClusters Cluster="ElectricalMeasurement" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
       <OutputClusters Cluster="Basic" TxAPDUs="QBKG11LM->apduZCL" Discoverable="true"/>
       <OutputClusters Cluster="OTA" TxAPDUs="QBKG11LM->apduZCL" Discoverable="true"/>
     </Endpoints>

--- a/src/HelloZigbee.zpscfg
+++ b/src/HelloZigbee.zpscfg
@@ -938,6 +938,8 @@
       <InputClusters Cluster="Default" RxAPDU="QBKG12LM->apduZCL" Discoverable="false"/>
       <InputClusters Cluster="Identify" RxAPDU="QBKG12LM->apduZCL" Discoverable="true"/>
       <InputClusters Cluster="DeviceTemperature" RxAPDU="QBKG12LM->apduZCL" Discoverable="true"/>
+      <InputClusters Cluster="ElectricalMeasurement" RxAPDU="QBKG12LM->apduZCL" Discoverable="true"/>
+      <InputClusters Cluster="SimpleMetering" RxAPDU="QBKG12LM->apduZCL" Discoverable="true"/>
       <OutputClusters Cluster="Basic" TxAPDUs="QBKG12LM->apduZCL" Discoverable="true"/>
       <OutputClusters Cluster="OTA" TxAPDUs="QBKG12LM->apduZCL" Discoverable="true"/>
     </Endpoints>

--- a/src/HelloZigbee.zpscfg
+++ b/src/HelloZigbee.zpscfg
@@ -100,6 +100,7 @@
     <Clusters Name="MultistateInput" Id="0x0012"/>
     <Clusters Name="DeviceTemperature" Id="0x0002"/>
     <Clusters Name="ElectricalMeasurement" Id="0x0B04"/>
+    <Clusters Name="SimpleMetering" Id="0x0702"/>
   </Profiles>
   <Coordinator Name="Coordinator" DiscoveryNeighbourTableSize="16" ActiveNeighbourTableSize="10" RouteDiscoveryTableSize="16" RoutingTableSize="16" BroadcastTransactionTableSize="9" RouteRecordTableSize="4" AddressMapTableSize="10" SecurityMaterialSets="2" MaxNumSimultaneousApsdeReq="5" MaxNumSimultaneousApsdeAckReq="3" MACMutexName="mutexMAC" ZPSMutexName="mutexZPS" FragmentationMaxNumSimulRx="0" FragmentationMaxNumSimulTx="0" DefaultEventMessageName="APP_vZpsEventHandler" MACDcfmIndMessage="zps_msgDcfmInd" MACTimeEventMessage="zps_msgTimeEvents" apsNonMemberRadius="2" apsDesignatedCoordinator="true" apsUseInsecureJoin="true" apsMaxWindowSize="8" apsInterframeDelay="10" APSDuplicateTableSize="8" apsSecurityTimeoutPeriod="1000" apsUseExtPANId="0x0000000000000000" SecurityEnabled="false" MACMlmeDcfmIndMessage="zps_msgMlmeDcfmInd" MACMcpsDcfmIndMessage="zps_msgMcpsDcfmInd" APSPersistenceTime="100" NumAPSMESimulCommands="4" StackProfile="2" InterPAN="false" GreenPowerSupport="false" NwkFcSaveCountBitShift="4" ApsFcSaveCountBitShift="4" MacTableSize="36" DefaultCallbackName="APP_vGenCallback" PermitJoiningTime="255" ChildTableSize="5">
     <Endpoints Id="0" Enabled="true" ApplicationDeviceId="0" ApplicationDeviceVersion="0" Profile="ZDP" Name="ZDO">
@@ -716,6 +717,7 @@
       <InputClusters Cluster="Identify" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
       <InputClusters Cluster="DeviceTemperature" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
       <InputClusters Cluster="ElectricalMeasurement" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
+      <InputClusters Cluster="SimpleMetering" RxAPDU="QBKG11LM->apduZCL" Discoverable="true"/>
       <OutputClusters Cluster="Basic" TxAPDUs="QBKG11LM->apduZCL" Discoverable="true"/>
       <OutputClusters Cluster="OTA" TxAPDUs="QBKG11LM->apduZCL" Discoverable="true"/>
     </Endpoints>

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -22,6 +22,9 @@ extern "C"
 #include "LEDTask.h"
 #include "BlinkTask.h"
 #include "RelayTask.h"
+#ifdef SUPPORTS_POWER_METERING
+#include "EnergyMeterTask.h"
+#endif
 #include "DumpFunctions.h"
 #include "DebugInput.h"
 
@@ -35,15 +38,16 @@ extern "C"
 }
 
 
-// 7 timers are:
+// 8 timers are:
 // - 1 in ButtonTask
 // - 1 in LEDTask
 // - 1 in RelayTask
 // - 1 in Heartbeat BlinkTask
 // - 1 in PollTask
+// - 1 in EnergyMeterTask
 // - 1 is ZCL timer
 // Note: if not enough space in this timers array, some of the functions (e.g. network joining) may not work properly
-ZTIMER_tsTimer timers[7 + BDB_ZTIMER_STORAGE];
+ZTIMER_tsTimer timers[8 + BDB_ZTIMER_STORAGE];
 
 extern "C" void __cxa_pure_virtual(void) __attribute__((__noreturn__));
 extern "C" void __cxa_deleted_virtual(void) __attribute__((__noreturn__));
@@ -141,6 +145,9 @@ extern "C" PUBLIC void vAppMain(void)
     ButtonsTask::getInstance()->start();
     LEDTask::getInstance();
     RelayTask::getInstance();
+#ifdef SUPPORTS_POWER_METERING
+    EnergyMeterTask::getInstance();
+#endif
 
     // Initialize the heartbeat LED (if there is one)
 #ifdef HEARTBEAT_LED_MASK

--- a/src/PdmIds.h
+++ b/src/PdmIds.h
@@ -6,6 +6,7 @@
 
 const uint8 PDM_ID_NODE_STATE 	= 1;
 const uint8 PDM_ID_OTA_DATA 	= 2;
+const uint8 PDM_ID_ENERGY 	= 3;
 
 const uint8 PDM_ID_EP_DATA_BASE = 0x10;
 

--- a/src/SimpleMetering.c
+++ b/src/SimpleMetering.c
@@ -1,0 +1,1176 @@
+/*
+ * PATCHED copy of sdk/Components/ZCL/Clusters/SmartEnergy/Source/SimpleMetering.c (JN-SW-4170).
+ * Delta: E_ZCL_AF_RP added to CurrentSummationDelivered (server attribute set) so the energy
+ * register is reportable - the ZCL reporting engine skips attributes without the RP flag.
+ */
+/*****************************************************************************
+ *
+ * MODULE:             Simple Metering Cluster
+ *
+ * COMPONENT:          SimpleMetering.c
+ *
+ * AUTHOR:             Lee Mitchell
+ *
+ * DESCRIPTION:        Simple Metering Cluster Definition
+ *
+ * $HeadURL: https://www.collabnet.nxp.com/svn/lprf_sware/Projects/Components/ZCL/Trunk/Clusters/SmartEnergy/Source/SimpleMetering.c $
+ *
+ * $Revision: 90669 $
+ *
+ * $LastChangedBy: nxp29741 $
+ *
+ * $LastChangedDate: 2017-10-17 18:21:47 +0200 (Tue, 17 Oct 2017) $
+ *
+ * $Id: SimpleMetering.c 90669 2017-10-17 16:21:47Z nxp29741 $
+ *
+ *****************************************************************************
+ *
+ * This software is owned by NXP B.V. and/or its supplier and is protected
+ * under applicable copyright laws. All rights are reserved. We grant You,
+ * and any third parties, a license to use this software solely and
+ * exclusively on NXP products [NXP Microcontrollers such as JN5168, JN5164,
+ * JN5161, JN5148, JN5142, JN5139].
+ * You, and any third parties must reproduce the copyright and warranty notice
+ * and any other legend of ownership on each  copy or partial copy of the software.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Copyright NXP B.V. 2012. All rights reserved
+ *
+ ****************************************************************************/
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <jendefs.h>
+#include "zcl.h"
+#include "zcl_options.h"
+#include "SimpleMetering.h"
+
+
+
+#ifdef CLD_SIMPLE_METERING
+/****************************************************************************/
+/***        Macro Definitions                                             ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Type Definitions                                              ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Local Function Prototypes                                     ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Exported Variables                                            ***/
+/****************************************************************************/
+
+/****************************************************************************/
+/***        Local Variables                                               ***/
+/****************************************************************************/
+
+/* Define the attributes in the simple metering cluster */
+const tsZCL_AttributeDefinition asCLD_SimpleMeteringClusterAttributeDefinitions[] = {
+
+    /* Reading information attribute set attribute ID's (D.3.2.2.1) */
+    {E_CLD_SM_ATTR_ID_CURRENT_SUMMATION_DELIVERED,          (E_ZCL_AF_RD|E_ZCL_AF_RP),     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentSummationDelivered), 0}
+
+#ifdef CLD_SM_ATTR_CURRENT_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_SUMMATION_RECEIVED,           E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentSummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MAX_DEMAND_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_DELIVERED,         E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentMaxDemandDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MAX_DEMAND_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_RECEIVED,          E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentMaxDemandReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DFT_SUMMATION
+    ,{E_CLD_SM_ATTR_ID_DFT_SUMMATION,                        E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48DFTSummation), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DAILY_FREEZE_TIME
+    ,{E_CLD_SM_ATTR_ID_DAILY_FREEZE_TIME,                    E_ZCL_AF_RD,     E_ZCL_UINT16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16DailyFreezeTime), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_POWER_FACTOR
+    ,{E_CLD_SM_ATTR_ID_POWER_FACTOR,                         E_ZCL_AF_RD,     E_ZCL_INT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i8PowerFactor), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_READING_SNAPSHOT_TIME
+    ,{E_CLD_SM_ATTR_ID_READING_SNAPSHOT_TIME,                E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_SimpleMetering*)(0))->utctReadingSnapshotTime), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MAX_DEMAND_DELIVERED_TIME
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_DELIVERED_TIME,    E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_SimpleMetering*)(0))->utctCurrentMaxDemandDeliveredTime), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MAX_DEMAND_RECEIVED_TIME
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_RECEIVED_TIME,     E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_SimpleMetering*)(0))->utctCurrentMaxDemandReceivedTime), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DEFAULT_UPDATE_PERIOD
+    ,{E_CLD_SM_ATTR_ID_DEFAULT_UPDATE_PERIOD,                 E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8DefaultUpdatePeriod), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_FAST_POLL_UPDATE_PERIOD
+    ,{E_CLD_SM_ATTR_ID_FAST_POLL_UPDATE_PERIOD,                 E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8FastPollUpdatePeriod), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_BLOCK_PERIOD_CONSUMPTION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_BLOCK_PERIOD_CONSUMPTION_DELIVERED,     E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentBlockPeriodConsumptionDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DAILY_CONSUMPTION_TARGET
+    ,{E_CLD_SM_ATTR_ID_DAILY_CONSUMPTION_TARGET,     E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24DailyConsumptionTarget), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_BLOCK
+    ,{E_CLD_SM_ATTR_ID_CURRENT_BLOCK,     E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->e8CurrentBlock), 0}
+#endif
+
+#ifdef CLD_SM_SUPPORT_GET_PROFILE
+
+#ifdef CLD_SM_ATTR_PROFILE_INTERVAL_PERIOD
+    ,{E_CLD_SM_ATTR_ID_PROFILE_INTERVAL_PERIOD,             E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->eProfileIntervalPeriod), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_INTERVAL_READ_REPORTING_PERIOD
+    ,{E_CLD_SM_ATTR_ID_INTERVAL_READ_REPORTING_PERIOD,    E_ZCL_AF_RD,    E_ZCL_UINT16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16IntervalReadReportingPeriod), 0}
+#endif
+
+#endif // CLD_SM_SUPPORT_GET_PROFILE
+
+#ifdef CLD_SM_ATTR_PRESET_READING_TIME
+    ,{E_CLD_SM_ATTR_ID_PRESET_READING_TIME,    E_ZCL_AF_RD,    E_ZCL_UINT16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16PresetReadingTime), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_VOLUME_PER_REPORT
+    ,{E_CLD_SM_ATTR_ID_VOLUME_PER_REPORT,    E_ZCL_AF_RD,    E_ZCL_UINT16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16VolumePerReport), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_FLOW_RESTRICTION
+    ,{E_CLD_SM_ATTR_ID_FLOW_RESTRICTION,    E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8FlowRestriction), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_SUPPLY_STATUS
+    ,{E_CLD_SM_ATTR_ID_SUPPLY_STATUS,    E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8SupplyStatus), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_INLET_ENERGY_CARRIER_SUMMATION
+    ,{E_CLD_SM_ATTR_ID_CURRENT_INLET_ENERGY_CARRIER_SUMMATION,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentInletEnergyCarrierSummation), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_OUTLET_ENERGY_CARRIER_SUMMATION
+    ,{E_CLD_SM_ATTR_ID_CURRENT_OUTLET_ENERGY_CARRIER_SUMMATION,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentOutletEnergyCarrierSummation), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_INLET_TEMPERATURE
+    ,{E_CLD_SM_ATTR_ID_INLET_TEMPERATURE,    E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24InletTemperature), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_OUTLET_TEMPERATURE
+    ,{E_CLD_SM_ATTR_ID_OUTLET_TEMPERATURE,    E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24OutletTemperature), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CONTROL_TEMPERATURE
+    ,{E_CLD_SM_ATTR_ID_CONTROL_TEMPERATURE,    E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24ControlTemperature), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_INLET_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_INLET_ENERGY_CARRIER_DEMAND,    E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentInletEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_OUTLET_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_OUTLET_ENERGY_CARRIER_DEMAND,    E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentOutletEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_BLOCK_PERIOD_CONSUMPTION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_BLOCK_PERIOD_CONSUMPTION_DELIVERED,     E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48PreviousBlockPeriodConsumptionDelivered), 0}
+#endif
+
+    /* Time Of Use Information attribute attribute ID's set (D.3.2.2.2) */
+#ifdef CLD_SM_ATTR_CURRENT_TIER_1_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_1_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier1SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_1_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_1_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier1SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_2_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_2_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier2SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_2_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_2_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier2SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_3_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_3_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier3SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_3_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_3_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier3SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_4_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_4_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier4SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_4_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_4_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier4SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_5_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_5_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier5SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_5_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_5_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier5SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_6_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_6_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier6SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_6_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_6_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier6SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_7_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_7_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier7SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_7_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_7_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier7SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_8_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_8_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier8SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_8_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_8_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier8SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_9_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_9_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier9SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_9_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_9_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier9SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_10_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_10_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier10SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_10_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_10_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier10SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_11_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_11_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier11SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_11_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_11_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier11SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_12_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_12_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier12SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_12_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_12_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier12SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_13_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_13_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier13SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_13_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_13_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier13SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_14_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_14_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier14SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_14_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_14_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier14SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_15_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_15_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier15SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_TIER_15_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_15_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentTier15SummationReceived), 0}
+#endif
+
+    /* Meter status attribute set attribute ID's (D.3.2.2.3) */
+    ,{E_CLD_SM_ATTR_ID_STATUS,                               E_ZCL_AF_RD,     E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8MeterStatus), 0}
+
+#ifdef CLD_SM_ATTR_REMAINING_BATTERY_LIFE
+    ,{E_CLD_SM_ATTR_ID_REMAINING_BATTERY_LIFE,    E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8RemainingBatteryLife), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_HOURS_IN_OPERATION
+    ,{E_CLD_SM_ATTR_ID_HOURS_IN_OPERATION,    E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24HoursInOperation), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_HOURS_IN_FAULT
+    ,{E_CLD_SM_ATTR_ID_HOURS_IN_FAULT,    E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24HoursInFault), 0}
+#endif
+
+    /* Formatting attribute set attribute ID's (D.3.2.2.4) */
+    ,{E_CLD_SM_ATTR_ID_UNIT_OF_MEASURE,                      E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->eUnitOfMeasure), 0}
+
+#ifdef CLD_SM_ATTR_MULTIPLIER
+    ,{E_CLD_SM_ATTR_ID_MULTIPLIER,                           E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24Multiplier), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DIVISOR
+    ,{E_CLD_SM_ATTR_ID_DIVISOR,                              E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24Divisor), 0}
+#endif
+
+    ,{E_CLD_SM_ATTR_ID_SUMMATION_FORMATING,                  E_ZCL_AF_RD,     E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8SummationFormatting), 0}
+
+#ifdef CLD_SM_ATTR_DEMAND_FORMATING
+    ,{E_CLD_SM_ATTR_ID_DEMAND_FORMATING,                     E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8DemandFormatting), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_HISTORICAL_CONSUMPTION_FORMATTING
+    ,{E_CLD_SM_ATTR_ID_HISTORICAL_CONSUMPTION_FORMATTING,    E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8HistoricalConsumptionFormatting), 0}
+#endif
+
+    ,{E_CLD_SM_ATTR_ID_METERING_DEVICE_TYPE,                 E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->eMeteringDeviceType), 0}
+#ifdef CLD_SM_ATTR_SITE_ID
+    ,{E_CLD_SM_ATTR_ID_SITE_ID,    E_ZCL_AF_RD,    E_ZCL_OSTRING,    (uint32)(&((tsCLD_SimpleMetering*)(0))->sSiteId), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_METER_SERIAL_NUMBER
+    ,{E_CLD_SM_ATTR_ID_METER_SERIAL_NUMBER,    E_ZCL_AF_RD,    E_ZCL_OSTRING,    (uint32)(&((tsCLD_SimpleMetering*)(0))->sMeterSerialNumber), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_ENERGY_CARRIER_UNIT_OF_MEASURE
+    ,{E_CLD_SM_ATTR_ID_ENERGY_CARRIER_UNIT_OF_MEASURE,    E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->e8EnergyCarrierUnitOfMeasure), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_ENERGY_CARRIER_SUMMATION_FORMATTING
+    ,{E_CLD_SM_ATTR_ID_ENERGY_CARRIER_SUMMATION_FORMATTING,    E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8EnergyCarrierSummationFormatting), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_ENERGY_CARRIER_DEMAND_FORMATTING
+    ,{E_CLD_SM_ATTR_ID_ENERGY_CARRIER_DEMAND_FORMATTING,    E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8EnergyCarrierDemandFormatting), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_TEMPERATURE_UNIT_OF_MEASURE
+    ,{E_CLD_SM_ATTR_ID_TEMPERATURE_UNIT_OF_MEASURE,    E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->e8TemperatureUnitOfMeasure), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_TEMPERATURE_FORMATTING
+    ,{E_CLD_SM_ATTR_ID_TEMPERATURE_FORMATTING,    E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8TemperatureFormatting), 0}
+#endif
+
+    /* ESP Historical Consumption set attribute ID's (D.3.2.2.5) */
+#ifdef CLD_SM_ATTR_INSTANTANEOUS_DEMAND
+    ,{E_CLD_SM_ATTR_ID_INSTANTANEOUS_DEMAND,                                     E_ZCL_AF_RD,     E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24InstantaneousDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_DAY_CONSUMPTION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_CONSUMPTION_DELIVERED,                        E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24CurrentDayConsumptionDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_DAY_CONSUMPTION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_CONSUMPTION_RECEIVED,                         E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24CurrentDayConsumptionReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_DAY_CONSUMPTION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_CONSUMPTION_DELIVERED,                       E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24PreviousDayConsumptionDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_DAY_CONSUMPTION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_CONSUMPTION_RECEIVED,                        E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24PreviousDayConsumptionReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_DELIVERED,    E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_SimpleMetering*)(0))->utctCurrentPartialProfileIntervalStartTimeDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_RECEIVED,     E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_SimpleMetering*)(0))->utctCurrentPartialProfileIntervalStartTimeReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED,         E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24CurrentPartialProfileIntervalValueDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED,          E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24CurrentPartialProfileIntervalValueReceived), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_DAY_MAXIMUM_PRESSURE
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_MAXIMUM_PRESSURE,                        E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentDayMaxPressure), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_DAY_MINIMUM_PRESSURE
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_MINIMUM_PRESSURE,                        E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48CurrentDayMinPressure), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_DAY_MAXIMUM_PRESSURE
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_MAXIMUM_PRESSURE,                       E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48PreviousDayMaxPressure), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_DAY_MINIMUM_PRESSURE
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_MINIMUM_PRESSURE,                       E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48PreviousDayMinPressure), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_DAY_MAXIMUM_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_MAXIMUM_DEMAND,                          E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentDayMaxDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_DAY_MAXIMUM_DEMAND
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_MAXIMUM_DEMAND,                         E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24PreviousDayMaxDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MONTH_MAXIMUM_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MONTH_MAXIMUM_DEMAND,                        E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentMonthMaxDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_YEAR_MAXIMUM_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_YEAR_MAXIMUM_DEMAND,                         E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentYearMaxDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_DAY_MAXIMUM_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_MAXIMUM_ENERGY_CARRIER_DEMAND,           E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentDayMaxEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PREVIOUS_DAY_MAXIMUM_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_MAXIMUM_ENERGY_CARRIER_DEMAND,          E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24PreviousDayMaxEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MONTH_MAXIMUM_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MONTH_MAXIMUM_ENERGY_CARRIER_DEMAND,          E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentMonthMaxEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_MONTH_MINIMUM_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MONTH_MINIMUM_ENERGY_CARRIER_DEMAND,          E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentMonthMinEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_YEAR_MAXIMUM_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_YEAR_MAXIMUM_ENERGY_CARRIER_DEMAND,          E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentYearMaxEnergyCarrierDemand), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_YEAR_MINIMUM_ENERGY_CARRIER_DEMAND
+    ,{E_CLD_SM_ATTR_ID_CURRENT_YEAR_MINIMUM_ENERGY_CARRIER_DEMAND,          E_ZCL_AF_RD,    E_ZCL_INT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->i24CurrentYearMinEnergyCarrierDemand), 0}
+#endif
+
+    /* Load Profile attribute set attribute ID's (D.3.2.2.6) */
+#ifdef CLD_SM_ATTR_MAX_NUMBER_OF_PERIODS_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_MAX_NUMBER_OF_PERIODS_DELIVERED,                     E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8MaxNumberOfPeriodsDelivered), 0}
+#endif
+
+    /* Supply Limit attribute set attribute ID's (D.3.2.2.7) */
+#ifdef CLD_SM_ATTR_CURRENT_DEMAND_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DEMAND_DELIVERED,                            E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24CurrentDemandDelivered), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DEMAND_LIMIT
+    ,{E_CLD_SM_ATTR_ID_DEMAND_LIMIT,                                        E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24DemandLimit), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_DEMAND_INTEGRATION_PERIOD
+    ,{E_CLD_SM_ATTR_ID_DEMAND_INTEGRATION_PERIOD,                           E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8DemandIntegrationPeriod), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_NUMBER_OF_DEMAND_SUBINTERVALS
+    ,{E_CLD_SM_ATTR_ID_NUMBER_OF_DEMAND_SUBINTERVALS,                       E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8NumberOfDemandSubintervals), 0}
+#endif
+
+    /* Block Information attribute set attribute ID's (D.3.2.2.8) */
+    /* No Tier Block Set */
+#if (CLD_SM_ATTR_NO_TIER_BLOCK_CURRENT_SUMMATION_DELIVERED_MAX_COUNT != 0)
+    ,{E_CLD_SM_ATTR_ID_CURRENT_NOTIER_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentNoTierBlockSummationDelivered[0]), CLD_SM_ATTR_NO_TIER_BLOCK_CURRENT_SUMMATION_DELIVERED_MAX_COUNT -1}
+#endif
+
+    /* Tier1 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 0)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER1_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier1BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier2 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 1)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER2_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier2BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier3 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 2)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER3_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier3BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier4 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 3)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER4_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier4BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier5 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 4)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER5_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier5BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier6 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 5)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER6_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier6BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier7 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 6)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER7_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier7BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier8 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 7)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER8_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier8BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier9 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 8)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER9_BLOCK1_SUMMATION_DELIVERED,            E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier9BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier10 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 9)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER10_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier10BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier11 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 10)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER11_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier11BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier12 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 11)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER12_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier12BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier13 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 12)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER13_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier13BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier14 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 13)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER14_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier14BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Tier15 Block Set */
+#if ((CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED > 14)&&(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0))
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER15_BLOCK1_SUMMATION_DELIVERED,           E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->au48CurrentTier15BlockSummationDelivered[0]), CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED -1}
+#endif
+
+    /* Alarm attribute set attribute ID's (D.3.2.2.9) */
+#ifdef CLD_SM_ATTR_GENERIC_ALARM_MASK
+    ,{E_CLD_SM_ATTR_ID_GENERIC_ALARM_MASK,                                  (E_ZCL_AF_RD|E_ZCL_AF_WR),    E_ZCL_BMAP16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16GenericAlarmMask), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_ELECTRICITY_ALARM_MASK
+    ,{E_CLD_SM_ATTR_ID_ELECTRICITY_ALARM_MASK,                              (E_ZCL_AF_RD|E_ZCL_AF_WR),    E_ZCL_BMAP32,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u32ElectricityAlarmMask), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_PRESSURE_ALARM_MASK
+    ,{E_CLD_SM_ATTR_ID_PRESSURE_ALARM_MASK,                                 (E_ZCL_AF_RD|E_ZCL_AF_WR),    E_ZCL_BMAP16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16PressureAlarmMask), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_WATER_SPECIFIC_ALARM_MASK
+    ,{E_CLD_SM_ATTR_ID_WATER_SPECIFIC_ALARM_MASK,                           (E_ZCL_AF_RD|E_ZCL_AF_WR),    E_ZCL_BMAP16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16WaterSpecificAlarmMask), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_HEAT_AND_COOLING_ALARM_MASK
+    ,{E_CLD_SM_ATTR_ID_HEAT_AND_COOLING_SPECIFIC_ALARM_MASK,                (E_ZCL_AF_RD|E_ZCL_AF_WR),    E_ZCL_BMAP16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16HeatAndCoolingSpecificAlarmMask), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_GAS_ALARM_MASK
+    ,{E_CLD_SM_ATTR_ID_GAS_ALARM_MASK,                                      (E_ZCL_AF_RD|E_ZCL_AF_WR),    E_ZCL_BMAP16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16GasAlarmMask), 0}
+#endif
+
+    /* Manufacturer Specific Attributes */
+#ifdef CLD_SM_ATTR_MAN_SPEC_AC_FREQUENCY
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_AC_FREQUENCY,                               (E_ZCL_AF_RD|E_ZCL_AF_MS),     E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8ManSpecACFrequency), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_RMS_VOLTAGE
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_RMS_VOLTAGE,                                (E_ZCL_AF_RD|E_ZCL_AF_MS),   E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecRMSVoltage), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_RMS_CURRENT
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_RMS_CURRENT,                                (E_ZCL_AF_RD|E_ZCL_AF_MS),   E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecRMSCurrent), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_ACTIVE_POWER
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_ACTIVE_POWER,                               (E_ZCL_AF_RD|E_ZCL_AF_MS),   E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecActivePower), 0}
+#endif
+    /* Manufacturer Specific Attributes: Calibration */
+#ifdef CLD_SM_ATTR_MAN_SPEC_CALIBRATION_VPP
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_VPP,                            (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecCalibrationVpp), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_CALIBRATION_I1PP
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_I1PP,                           (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecCalibrationI1pp), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_CALIBRATION_I2PP
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_I2PP,                           (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecCalibrationI2pp), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_CALIBRATION_DELTAPHI1
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_DELTAPHI1,                      (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecCalibrationDeltaPhi1), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_CALIBRATION_DELTAPHI2
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_DELTAPHI2,                      (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),    E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecCalibrationDeltaPhi2), 0}
+#endif
+
+#ifdef CLD_SM_ATTR_MAN_SPEC_CALIBRATION_DIVISOR
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_DIVISOR,                        (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT24,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u24ManSpecCalibrationDivisor), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_POWER_THRESHOLD
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_POWER_THRESHOLD,                            (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u48ManSpecPowerThreshold), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_UPDATE_INTERVAL
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_UPDATE_INTERVAL,                            (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT16,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u16ManSpecUpdateInterval), 0}
+#endif
+#ifdef CLD_SM_ATTR_MAN_SPEC_RF_POWER_CONFIG
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_RF_POWER_CONFIG,                            (E_ZCL_AF_RD|E_ZCL_AF_WR|E_ZCL_AF_MS),     E_ZCL_UINT8,    (uint32)(&((tsCLD_SimpleMetering*)(0))->u8ManSpecRfPowerConfig), 0}
+#endif
+};
+
+#if(CLD_SM_ATTR_NO_TIER_BLOCK_CURRENT_SUMMATION_DELIVERED_MAX_COUNT != 0)
+#define CLD_SM_ATTR_NUM_OF_CURRENT_SUMMATION_DELIVERED         CLD_SM_ATTR_NO_TIER_BLOCK_CURRENT_SUMMATION_DELIVERED_MAX_COUNT - 1
+#elif (CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED != 0)
+#define CLD_SM_ATTR_NUM_OF_CURRENT_SUMMATION_DELIVERED         CLD_SM_ATTR_NUM_OF_TIERS_CURRENT_SUMMATION_DELIVERED*(CLD_SM_ATTR_NUM_OF_BLOCKS_IN_EACH_TIER_CURRENT_SUMMATION_DELIVERED - 1)
+#else
+#define CLD_SM_ATTR_NUM_OF_CURRENT_SUMMATION_DELIVERED         0
+#endif
+
+#define SM_NUM_OF_ATTRIBUTES      sizeof(asCLD_SimpleMeteringClusterAttributeDefinitions) / sizeof(tsZCL_AttributeDefinition) + \
+                                  CLD_SM_ATTR_NUM_OF_CURRENT_SUMMATION_DELIVERED
+
+#ifdef ZCL_COMMAND_DISCOVERY_SUPPORTED
+const tsZCL_CommandDefinition asCLD_SimpleMeteringClusterCommandDefinitions[] = {
+    {E_CLD_SM_GET_PROFILE,                     E_ZCL_CF_RX},     /* Mandatory */
+    {E_CLD_SM_REQUEST_FAST_POLL_MODE,          E_ZCL_CF_RX},     /* Mandatory */
+    {E_CLD_SM_REQUEST_MIRROR_RESPONSE,         E_ZCL_CF_RX},     /* Mandatory */    
+    {E_CLD_SM_MIRROR_REMOVED,                  E_ZCL_CF_RX},      /* Mandatory */ 
+    
+    {E_CLD_SM_GET_PROFILE_RESPONSE,            E_ZCL_CF_TX},     /* Mandatory */
+    {E_CLD_SM_REQUEST_FAST_POLL_MODE_RESPONSE, E_ZCL_CF_TX},     /* Mandatory */
+    {E_CLD_SM_REQUEST_MIRROR,                  E_ZCL_CF_TX}  
+    
+};
+#endif                                  
+tsZCL_ClusterDefinition sCLD_SimpleMetering = {
+        SE_CLUSTER_ID_SIMPLE_METERING,
+        FALSE,
+        E_ZCL_SECURITY_NETWORK,
+        SM_NUM_OF_ATTRIBUTES,
+        (tsZCL_AttributeDefinition*)asCLD_SimpleMeteringClusterAttributeDefinitions,
+        NULL
+#ifdef ZCL_COMMAND_DISCOVERY_SUPPORTED        
+        ,
+        (sizeof(asCLD_SimpleMeteringClusterCommandDefinitions) / sizeof(tsZCL_CommandDefinition)),
+        (tsZCL_CommandDefinition*)asCLD_SimpleMeteringClusterCommandDefinitions         
+#endif        
+
+};
+#ifdef SM_SERVER
+uint8 au8SimpleMeteringServerAttributeControlBits[SM_NUM_OF_ATTRIBUTES];
+#endif
+
+tsZCL_ClusterDefinition sCLD_SMClientNoAttribute = {
+        SE_CLUSTER_ID_SIMPLE_METERING,
+        FALSE,
+        E_ZCL_SECURITY_NETWORK,
+        0,
+        NULL
+};
+
+
+#ifdef CLD_SM_SUPPORT_MIRROR
+/*
+ * Attribute Definition for Simple metering cluster
+ * Required for Mirroring
+ */
+const tsZCL_AttributeDefinition asCLD_SMMirrorClusterAttributeDefinitions[] = {
+
+    /* Reading information attribute set attribute ID's (D.3.2.2.1) */
+    {E_CLD_SM_ATTR_ID_CURRENT_SUMMATION_DELIVERED,          E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentSummationDelivered), 0}
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_SUMMATION_RECEIVED,           E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentSummationReceived),0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_MAX_DEMAND_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_DELIVERED,         E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentMaxDemandDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_MAX_DEMAND_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_RECEIVED,          E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentMaxDemandReceived),0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_DFT_SUMMATION
+    ,{E_CLD_SM_ATTR_ID_DFT_SUMMATION,                        E_ZCL_AF_RD,     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48DFTSummation), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_DAILY_FREEZE_TIME
+    ,{E_CLD_SM_ATTR_ID_DAILY_FREEZE_TIME,                    E_ZCL_AF_RD,     E_ZCL_UINT16,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u16DailyFreezeTime), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_POWER_FACTOR
+    ,{E_CLD_SM_ATTR_ID_POWER_FACTOR,                         E_ZCL_AF_RD,     E_ZCL_INT8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->i8PowerFactor), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_READING_SNAPSHOT_TIME
+    ,{E_CLD_SM_ATTR_ID_READING_SNAPSHOT_TIME,                E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_Mirror_SM*)(0))->utctReadingSnapshotTime), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_MAX_DEMAND_DELIVERED_TIME
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_DELIVERED_TIME,    E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_Mirror_SM*)(0))->utctCurrentMaxDemandDeliveredTime), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_MAX_DEMAND_RECEIVED_TIME
+    ,{E_CLD_SM_ATTR_ID_CURRENT_MAX_DEMAND_RECEIVED_TIME,     E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_Mirror_SM*)(0))->utctCurrentMaxDemandReceivedTime), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_PROFILE_INTERVAL_PERIOD
+    ,{E_CLD_SM_ATTR_ID_PROFILE_INTERVAL_PERIOD,             E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->eProfileIntervalPeriod), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_INTERVAL_READ_REPORTING_PERIOD
+    ,{E_CLD_SM_ATTR_ID_INTERVAL_READ_REPORTING_PERIOD,    E_ZCL_AF_RD,    E_ZCL_UINT16,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u32IntervalReadReportingPeriod), 0}
+#endif
+
+    /* Time Of Use Information attribute attribute ID's set (D.3.2.2.2) */
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_1_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_1_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier1SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_1_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_1_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier1SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_2_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_2_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier2SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_2_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_2_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier2SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_3_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_3_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier3SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_3_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_3_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier3SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_4_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_4_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier4SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_4_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_4_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier4SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_5_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_5_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier5SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_5_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_5_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier5SummationReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_6_SUMMATION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_6_SUMMATION_DELIVERED,   E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier6SummationDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_TIER_6_SUMMATION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_TIER_6_SUMMATION_RECEIVED,    E_ZCL_AF_RD,    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48CurrentTier6SummationReceived), 0}
+#endif
+
+    /* Meter status attribute set attribute ID's (D.3.2.2.3) */
+    ,{E_CLD_SM_ATTR_ID_STATUS,                               E_ZCL_AF_RD,     E_ZCL_BMAP8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8MeterStatus), 0}
+
+    /* Formatting attribute set attribute ID's (D.3.2.2.4) */
+    ,{E_CLD_SM_ATTR_ID_UNIT_OF_MEASURE,                      E_ZCL_AF_RD,    E_ZCL_ENUM8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->eUnitOfMeasure), 0}
+
+#ifdef CLD_SM_MIRROR_ATTR_MULTIPLIER
+    ,{E_CLD_SM_ATTR_ID_MULTIPLIER,                           E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24Multiplier), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_DIVISOR
+    ,{E_CLD_SM_ATTR_ID_DIVISOR,                              E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24Divisor), 0}
+#endif
+
+    ,{E_CLD_SM_ATTR_ID_SUMMATION_FORMATING,                  E_ZCL_AF_RD,     E_ZCL_BMAP8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8SummationFormatting), 0}
+
+#ifdef CLD_SM_MIRROR_ATTR_DEMAND_FORMATING
+    ,{E_CLD_SM_ATTR_ID_DEMAND_FORMATING,                     E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8DemandFormatting), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_HISTORICAL_CONSUMPTION_FORMATTING
+    ,{E_CLD_SM_ATTR_ID_HISTORICAL_CONSUMPTION_FORMATTING,    E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8HistoricalConsumptionFormatting), 0}
+#endif
+
+    ,{E_CLD_SM_ATTR_ID_METERING_DEVICE_TYPE,                 E_ZCL_AF_RD,    E_ZCL_BMAP8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8MeteringDeviceType), 0}
+
+#ifdef CLD_SM_MIRROR_ATTR_METER_SERIAL_NUMBER
+    ,{E_CLD_SM_ATTR_ID_METER_SERIAL_NUMBER,                  E_ZCL_AF_RD,    E_ZCL_OSTRING,  (uint32)(&((tsCLD_Mirror_SM*)(0))->sMeterSerialNumber), 0}
+#endif
+
+    /* ESP Historical Consumption set attribute ID's (D.3.2.2.5) */
+#ifdef CLD_SM_MIRROR_ATTR_INSTANTANEOUS_DEMAND
+    ,{E_CLD_SM_ATTR_ID_INSTANTANEOUS_DEMAND,                                     E_ZCL_AF_RD,     E_ZCL_INT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->i24InstantaneousDemand), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_DAY_CONSUMPTION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_CONSUMPTION_DELIVERED,                        E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24CurrentDayConsumptionDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_DAY_CONSUMPTION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DAY_CONSUMPTION_RECEIVED,                         E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24CurrentDayConsumptionReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_PREVIOUS_DAY_CONSUMPTION_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_CONSUMPTION_DELIVERED,                       E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24PreviousDayConsumptionDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_PREVIOUS_DAY_CONSUMPTION_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_PREVIOUS_DAY_CONSUMPTION_RECEIVED,                        E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24PreviousDayConsumptionReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_DELIVERED,    E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_Mirror_SM*)(0))->utctCurrentPartialProfileIntervalStartTimeDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_RECEIVED,     E_ZCL_AF_RD,    E_ZCL_UTCT,    (uint32)(&((tsCLD_Mirror_SM*)(0))->utctCurrentPartialProfileIntervalStartTimeReceived), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED,         E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24CurrentPartialProfileIntervalValueDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED,          E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24CurrentPartialProfileIntervalValueReceived), 0}
+#endif
+
+    /* Load Profile attribute set attribute ID's (D.3.2.2.6) */
+#ifdef CLD_SM_MIRROR_ATTR_MAX_NUMBER_OF_PERIODS_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_MAX_NUMBER_OF_PERIODS_DELIVERED,  E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8MaxNumberOfPeriodsDelivered), 0}
+#endif
+
+    /* Supply Limit attribute set attribute ID's (D.3.2.2.7) */
+#ifdef CLD_SM_MIRROR_ATTR_CURRENT_DEMAND_DELIVERED
+    ,{E_CLD_SM_ATTR_ID_CURRENT_DEMAND_DELIVERED,         E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24CurrentDemandDelivered), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_DEMAND_LIMIT
+    ,{E_CLD_SM_ATTR_ID_DEMAND_LIMIT,                     E_ZCL_AF_RD,    E_ZCL_UINT24,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u24DemandLimit), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_DEMAND_INTEGRATION_PERIOD
+    ,{E_CLD_SM_ATTR_ID_DEMAND_INTEGRATION_PERIOD,        E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8DemandIntegrationPeriod), 0}
+#endif
+
+#ifdef CLD_SM_MIRROR_ATTR_NUMBER_OF_DEMAND_SUBINTERVALS
+    ,{E_CLD_SM_ATTR_ID_NUMBER_OF_DEMAND_SUBINTERVALS,    E_ZCL_AF_RD,    E_ZCL_UINT8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8NumberOfDemandSubintervals),0}
+#endif
+
+    /* Manufacturer Specific Attributes: Measurements */
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_AC_FREQUENCY
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_AC_FREQUENCY,        (E_ZCL_AF_RD | E_ZCL_AF_MS),    E_ZCL_UINT8,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u8ManSpecACFrequency), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_RMS_VOLTAGE
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_RMS_VOLTAGE,        (E_ZCL_AF_RD | E_ZCL_AF_MS),    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecRMSVoltage), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_RMS_CURRENT
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_RMS_CURRENT,        (E_ZCL_AF_RD | E_ZCL_AF_MS),    E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecRMSCurrent), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_ACTIVE_POWER
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_RMS_CURRENT,    (E_ZCL_AF_RD | E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecActivePower), 0}
+#endif
+
+    /* Manufacturer Specific Attributes: Calibration,Threshold,Update Interval */
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_CALIBRATION_VPP
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_VPP,    (E_ZCL_AF_RD |  E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecCalibrationVpp), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_CALIBRATION_I1PP
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_I1PP,   (E_ZCL_AF_RD | E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecCalibrationI1pp), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_CALIBRATION_I2PP
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_I2PP,   (E_ZCL_AF_RD | E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecCalibrationI2pp), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_CALIBRATION_DELTAPHI1
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_DELTAPHI1,  (E_ZCL_AF_RD | E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecCalibrationDeltaPhi1), 0}
+#endif
+#ifdef CLD_SM_MIRROR_ATTR_MAN_SPEC_CALIBRATION_DELTAPHI2
+    ,{E_CLD_SM_ATTR_ID_MAN_SPEC_CALIBRATION_DELTAPHI2,  (E_ZCL_AF_RD | E_ZCL_AF_MS),     E_ZCL_UINT48,    (uint32)(&((tsCLD_Mirror_SM*)(0))->u48ManSpecCalibrationDeltaPhi2), 0}
+#endif
+
+};
+
+/*NUMBER Of Mirrors*/
+tsZCL_ClusterDefinition sCLD_SM_Mirror[CLD_SM_NUMBER_OF_MIRRORS];
+uint8  au8SMMirrorClusterAttributeControlBits[CLD_SM_NUMBER_OF_MIRRORS][(sizeof(asCLD_SMMirrorClusterAttributeDefinitions) / sizeof(tsZCL_AttributeDefinition))];
+#endif /*CLD_SM_SUPPORT_MIRROR*/
+
+/****************************************************************************/
+/***        Exported Functions                                            ***/
+/****************************************************************************/
+/****************************************************************************
+ **
+ ** NAME:       eSE_SMCreate
+ **
+ ** DESCRIPTION: Configures Simple metering cluster
+ **
+ ** PARAMETERS:
+ ** u8Endpoint,                    : Cluster attached to which EP
+ ** bIsServer                    : Direction bit of a cluster
+ ** *psAttributeStatus,            : Pointer to Attribute status pointer
+ ** *psClusterInstance             : Cluster Instance
+ ** *psClusterDefinition         : cluster definition
+ ** *psCustomDataStruct            : Pointer to Custom Data structure for CallBacks
+ ** *pvEndPointSharedStructPtr    : Attribute space
+ **
+ **
+ **
+ ** RETURN:
+ **
+ ****************************************************************************/
+PUBLIC  teZCL_Status eSE_SMCreate(uint8                               u8Endpoint,
+                                                bool_t                              bIsServer,
+                                                uint8                              *pu8AttributeControlBits,
+                                                tsZCL_ClusterInstance              *psClusterInstance,
+                                                tsZCL_ClusterDefinition            *psClusterDefinition,
+                                                tsSM_CustomStruct                  *psCustomDataStruct,
+                                                void                               *pvEndPointSharedStructPtr)
+{
+
+    teZCL_Status eZCLstatus = E_ZCL_SUCCESS;
+#if defined( CLD_SM_ATTR_SITE_ID) || defined (CLD_SM_ATTR_METER_SERIAL_NUMBER )
+    tsCLD_SimpleMetering *psCLD_SimpleMetering;
+#endif
+#ifdef CLD_SM_SUPPORT_GET_PROFILE
+#ifdef SM_SERVER
+    uint8 u8LoopCntr = 0;
+#endif
+#endif
+
+    #ifdef STRICT_PARAM_CHECK 
+        if((psClusterInstance==NULL)            ||
+           (psClusterDefinition==NULL)          ||
+           (psCustomDataStruct == NULL)
+           )
+        {
+            return E_ZCL_ERR_PARAMETER_NULL;
+        }
+    #endif
+
+    // cluster data
+    vZCL_InitializeClusterInstance(
+                                   psClusterInstance, 
+                                   bIsServer,
+                                   psClusterDefinition,
+                                   pvEndPointSharedStructPtr,
+                                   pu8AttributeControlBits,
+                                   NULL,
+                                   eSimpleMeteringCommandHandler);     
+
+    psClusterInstance->pvEndPointCustomStructPtr = psCustomDataStruct;
+    psCustomDataStruct->sSMCustomCallBackEvent.eEventType = E_ZCL_CBET_CLUSTER_CUSTOM;
+    psCustomDataStruct->sSMCustomCallBackEvent.psClusterInstance = psClusterInstance;
+    psCustomDataStruct->sSMCustomCallBackEvent.u8EndPoint = u8Endpoint;
+    psCustomDataStruct->sSMCustomCallBackEvent.uMessage.sClusterCustomMessage.u16ClusterId = SE_CLUSTER_ID_SIMPLE_METERING;
+    psCustomDataStruct->sSMCustomCallBackEvent.uMessage.sClusterCustomMessage.pvCustomData = (void*)&psCustomDataStruct->sSMCallBackMessage;
+#if defined( CLD_SM_ATTR_SITE_ID) || defined (CLD_SM_ATTR_METER_SERIAL_NUMBER )
+    //  attributes set default values
+    psCLD_SimpleMetering = (tsCLD_SimpleMetering *)pvEndPointSharedStructPtr;
+
+    /* If both SM_Server & SM_Client enabled, when creating client cluster instance NULL is passed for end point shared structure */
+    if(pvEndPointSharedStructPtr)
+    {
+#ifdef CLD_SM_ATTR_SITE_ID
+        psCLD_SimpleMetering->sSiteId.u8MaxLength = SE_SM_SITE_ID_MAX_STRING_LENGTH;
+        psCLD_SimpleMetering->sSiteId.u8Length = 0;
+        psCLD_SimpleMetering->sSiteId.pu8Data = psCLD_SimpleMetering->au8SiteId;
+#endif
+
+#ifdef CLD_SM_ATTR_METER_SERIAL_NUMBER
+        psCLD_SimpleMetering->sMeterSerialNumber.u8MaxLength = SE_SM_METER_SERIAL_NUMBER_MAX_STRING_LENGTH;
+        psCLD_SimpleMetering->sMeterSerialNumber.u8Length = 0;
+        psCLD_SimpleMetering->sMeterSerialNumber.pu8Data = psCLD_SimpleMetering->au8MeterSerialNumber;
+#endif
+    }
+
+
+
+#ifdef    CLD_SM_SUPPORT_FAST_POLL_MODE
+
+    if (bIsServer)
+    {
+        eZCLstatus = eSM_RegisterTimeServer();
+    }
+
+#endif
+
+#ifdef CLD_SM_SUPPORT_GET_PROFILE
+
+
+    if(bIsServer)
+    {
+        b8SupportedChannels = 0;
+#ifdef CLD_SM_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED
+        b8SupportedChannels = b8SupportedChannels | (1 << CLD_SM_PROFILE_INTERVAL_VALUE_DELIVERED);
+#endif
+
+#ifdef CLD_SM_ATTR_CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED
+        b8SupportedChannels = b8SupportedChannels | (1 << CLD_SM_PROFILE_INTERVAL_VALUE_RECEIVED);
+#endif
+        /* Init the end time as 0xFFFFFFFF in circular buffer */
+        for (u8LoopCntr = 0; u8LoopCntr < CLD_SM_GETPROFILE_MAX_NO_INTERVALS; u8LoopCntr++)
+        {
+            sSEGetProfile[u8LoopCntr].u32UtcTime = 0xFFFFFFFF;
+        }
+
+        /* Init Max. number of periods are delivered */
+        if(pvEndPointSharedStructPtr)
+            psCLD_SimpleMetering->u8MaxNumberOfPeriodsDelivered = CLD_SM_GETPROFILE_MAX_NO_INTERVALS;
+    }
+#endif
+
+#endif
+    return eZCLstatus;
+}
+
+#ifdef CLD_SM_SUPPORT_MIRROR
+/****************************************************************************
+ *
+ * NAME: eSE_RegisterMirroredSMClusters
+ *
+ * DESCRIPTION:
+ * Registers a simple metering cluster with the ZCL layer, for each mirror
+ *
+ * PARAMETERS:  Name                            Usage
+ *
+ *
+ * RETURNS:
+ * Void
+ *
+ ****************************************************************************/
+PUBLIC  teZCL_Status eSE_RegisterMirroredSMClusters(uint8 u8MirrorNum,
+                                                                    uint8 u8MirrorStartEndPoint,
+                                                                    tsZCL_ClusterInstance *psClusterInstance,
+                                                                    void                  *pvEndPointSharedStructPtr,
+                                                                    tsSM_CustomStruct     *psCustomDataStruct)
+{
+
+    sCLD_SM_Mirror[u8MirrorNum].u16ClusterEnum = SE_CLUSTER_ID_SIMPLE_METERING;
+    sCLD_SM_Mirror[u8MirrorNum].bIsManufacturerSpecificCluster = FALSE;
+    sCLD_SM_Mirror[u8MirrorNum].u8ClusterControlFlags = (E_ZCL_SECURITY_NETWORK | CLUSTER_MIRROR_BIT);
+    sCLD_SM_Mirror[u8MirrorNum].u16NumberOfAttributes = (sizeof(asCLD_SMMirrorClusterAttributeDefinitions) / sizeof(tsZCL_AttributeDefinition));
+    sCLD_SM_Mirror[u8MirrorNum].psAttributeDefinition =  (tsZCL_AttributeDefinition*)asCLD_SMMirrorClusterAttributeDefinitions;
+
+    psClusterInstance->bIsServer = TRUE;
+    psClusterInstance->psClusterDefinition = &sCLD_SM_Mirror[u8MirrorNum];
+    psClusterInstance->pvEndPointSharedStructPtr = pvEndPointSharedStructPtr;
+    psClusterInstance->pu8AttributeControlBits = au8SMMirrorClusterAttributeControlBits[u8MirrorNum];
+    psClusterInstance->pCustomcallCallBackFunction = eSimpleMeteringCommandHandler;
+    psClusterInstance->pvEndPointCustomStructPtr = psCustomDataStruct;
+    psCustomDataStruct->sSMCustomCallBackEvent.eEventType = E_ZCL_CBET_CLUSTER_CUSTOM;
+    psCustomDataStruct->sSMCustomCallBackEvent.psClusterInstance = psClusterInstance;
+    psCustomDataStruct->sSMCustomCallBackEvent.u8EndPoint = u8MirrorStartEndPoint + u8MirrorNum;
+    psCustomDataStruct->sSMCustomCallBackEvent.uMessage.sClusterCustomMessage.u16ClusterId = SE_CLUSTER_ID_SIMPLE_METERING;
+    psCustomDataStruct->sSMCustomCallBackEvent.uMessage.sClusterCustomMessage.pvCustomData = (void*)&psCustomDataStruct->sSMCallBackMessage;
+#ifdef CLD_SM_MIRROR_ATTR_METER_SERIAL_NUMBER
+    ((tsCLD_Mirror_SM *)(pvEndPointSharedStructPtr))->sMeterSerialNumber.u8MaxLength = SE_SM_METER_SERIAL_NUMBER_MAX_STRING_LENGTH;
+    ((tsCLD_Mirror_SM *)(pvEndPointSharedStructPtr))->sMeterSerialNumber.u8Length = 0;
+    ((tsCLD_Mirror_SM *)(pvEndPointSharedStructPtr))->sMeterSerialNumber.pu8Data =
+        ((tsCLD_Mirror_SM *)(pvEndPointSharedStructPtr))->au8MeterSerialNumber;
+#endif
+
+
+
+    return E_ZCL_SUCCESS;
+}
+#endif /*CLD_SM_SUPPORT_MIRROR*/
+
+
+/****************************************************************************
+ **
+ ** NAME:       eSE_FindSimpleMeteringCluster
+ **
+ ** DESCRIPTION:
+ ** Search helper function
+ **
+ ** PARAMETERS:                     Name                        Usage
+ ** uint8                           u8SourceEndPointId          Source EP Id
+ ** bool_t                          bIsServer                   Is server
+ ** tsZCL_EndPointDefinition    **ppsEndPointDefinition         EP
+ ** tsZCL_ClusterInstance       **ppsClusterInstance            Cluster
+ ** tsSE_DRLCCustomDataStructure  **ppsDRLCCustomDataStructure  event data
+ **
+ ** RETURN:
+ ** teSE_DRLCStatus
+ **
+ ****************************************************************************/
+
+PUBLIC  teZCL_Status eSE_FindSimpleMeteringCluster(
+                                uint8                           u8SourceEndPointId,
+                                bool_t                          bIsServer,
+                                tsZCL_EndPointDefinition      **ppsEndPointDefinition,
+                                tsZCL_ClusterInstance         **ppsClusterInstance,
+                                tsSM_CustomStruct                **ppsSM_CustomStruct)
+{
+    // check EP is registered and cluster is present in the send device
+    if(eZCL_SearchForEPentry(u8SourceEndPointId, ppsEndPointDefinition) != E_ZCL_SUCCESS)
+    {
+        return(E_ZCL_ERR_EP_RANGE);
+    }
+
+    if(eZCL_SearchForClusterEntry(u8SourceEndPointId, SE_CLUSTER_ID_SIMPLE_METERING, bIsServer, ppsClusterInstance) != E_ZCL_SUCCESS)
+    {
+        return(E_ZCL_ERR_CLUSTER_NOT_FOUND);
+    }
+
+    // initialise custom data pointer
+    *ppsSM_CustomStruct = (tsSM_CustomStruct *)(*ppsClusterInstance)->pvEndPointCustomStructPtr;
+    if(*ppsSM_CustomStruct == NULL)
+    {
+        return(E_ZCL_ERR_CUSTOM_DATA_NULL);
+    }
+
+    return(E_ZCL_SUCCESS);
+}
+
+
+
+
+#endif  /*CLD_SIMPLE_METERING*/
+
+/****************************************************************************/
+/***        Local Functions                                               ***/
+/****************************************************************************/
+/****************************************************************************/
+/***        END OF FILE                                                   ***/
+/****************************************************************************/
+

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -153,29 +153,13 @@
     #define RELAY1_OFF_PIN              (12)
     #define RELAY1_OFF_MASK             (1UL << RELAY1_OFF_PIN)
 
-    // On-board HLW8012 energy metering IC (CF/CF1 are the pulse counters'
-    // default input pins; SEL is inverted by a 2N7002 on its way to the chip)
+    // On-board HLW8012 energy metering IC. CF (power) -> DIO8/PC1 and CF1
+    // (voltage/current, SEL-muxed) -> DIO1/PC0 are the pulse counters' fixed
+    // default inputs and need no pin configuration; SEL is inverted by a
+    // 2N7002 on its way to the chip.
     #define SUPPORTS_POWER_METERING
-    #define METERING_CF_PIN             (8)
-    #define METERING_CF_MASK            (1UL << METERING_CF_PIN)
-    #define METERING_CF1_PIN            (1)
-    #define METERING_CF1_MASK           (1UL << METERING_CF1_PIN)
     #define METERING_SEL_PIN            (9)
     #define METERING_SEL_MASK           (1UL << METERING_SEL_PIN)
-    // Conversion constants, scaled by 1e5: value = freq_dHz * K / 100000.
-    // Power: calibrated 2026-08-02 against an inline power meter (1910 W at
-    // 424.41 Hz CF over a 3 min pulse-count integration) -> 4.5004 W/Hz,
-    // +8.8 % over the datasheet-nominal 4.138 (shunt below its marked 2 mOhm).
-    #define METERING_W_PER_DHZ_E5       (45004)
-    // Voltage: calibrated 2026-08-02 against a UNI-T UT33D at the load
-    // terminals under load (235.5 V read vs 225.3 V displayed -> +4.53 % over
-    // the datasheet-nominal 0.32694 V/Hz).
-    #define METERING_DV_PER_DHZ_E5      (34176)
-    // Current: derived, not directly measured - all HLW8012 channels share
-    // Vref and the shunt, so Kc = Kp/Kv: 1.0876 / 1.0453 = 1.0405 over the
-    // datasheet-nominal 7.2423 mA/Hz. Cross-check: 8.40 A at 1910 W / 235.5 V
-    // -> PF 0.966, plausible for heater + universal motor.
-    #define METERING_MA_PER_DHZ_E5      (75357)
 
     #define BASIC_ENDPOINT              (QBKG11LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG11LM_SWITCH1_ENDPOINT)
@@ -212,6 +196,14 @@
     #define RELAY2_OFF_PIN              (12)
     #define RELAY2_OFF_MASK             (1UL << RELAY2_OFF_PIN)
 
+    // On-board HLW8012 energy metering IC. CF (power) -> DIO8/PC1 and CF1
+    // (voltage/current, SEL-muxed) -> DIO1/PC0 are the pulse counters' fixed
+    // default inputs and need no pin configuration; SEL is inverted by a
+    // 2N7002 on its way to the chip.
+    #define SUPPORTS_POWER_METERING
+    #define METERING_SEL_PIN            (9)
+    #define METERING_SEL_MASK           (1UL << METERING_SEL_PIN)
+
     #define BASIC_ENDPOINT              (QBKG12LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG12LM_SWITCH1_ENDPOINT)
     #define SWITCH2_ENDPOINT            (QBKG12LM_SWITCH2_ENDPOINT)
@@ -240,11 +232,9 @@
 #define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
 #define CLD_ELECTMEAS_ATTR_AC_CURRENT_MULTIPLIER
 #define CLD_ELECTMEAS_ATTR_AC_CURRENT_DIVISOR
-// Cumulative energy over the Simple Metering cluster (the SDK inconsistently
-// gates on both names: the cluster source uses CLD_SIMPLE_METERING, the
-// header structs use CLD_SM/SM_SERVER)
+// Cumulative energy over the Simple Metering cluster (the SDK gates the
+// cluster source on CLD_SIMPLE_METERING and the header structs on SM_SERVER)
 #define CLD_SIMPLE_METERING
-#define CLD_SM
 #define SM_SERVER
 #define CLD_SM_ATTR_MULTIPLIER
 #define CLD_SM_ATTR_DIVISOR

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -214,6 +214,11 @@
 #define CLD_ELECTMEAS_ATTR_ACTIVE_POWER
 #define CLD_ELECTMEAS_ATTR_RMS_VOLTAGE
 #define CLD_ELECTMEAS_ATTR_RMS_CURRENT
+// Cumulative CF/CF1 pulse counts ride in two manufacturer-specific uint32
+// attributes (0xFF00/0xFF01, manufacturer code 0x1037) so calibration can
+// integrate over minutes instead of trusting one 1 s window
+#define CLD_ELECTMEAS_ATTR_MAN_SPEC_APPARENT_POWER
+#define CLD_ELECTMEAS_ATTR_MAN_SPEC_NON_ACTIVE_POWER
 #endif
 
 #endif /* ZCL_OPTIONS_H */

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -153,6 +153,16 @@
     #define RELAY1_OFF_PIN              (12)
     #define RELAY1_OFF_MASK             (1UL << RELAY1_OFF_PIN)
 
+    // On-board HLW8012 energy metering IC (CF/CF1 are the pulse counters'
+    // default input pins; SEL is inverted by a 2N7002 on its way to the chip)
+    #define SUPPORTS_POWER_METERING
+    #define METERING_CF_PIN             (8)
+    #define METERING_CF_MASK            (1UL << METERING_CF_PIN)
+    #define METERING_CF1_PIN            (1)
+    #define METERING_CF1_MASK           (1UL << METERING_CF1_PIN)
+    #define METERING_SEL_PIN            (9)
+    #define METERING_SEL_MASK           (1UL << METERING_SEL_PIN)
+
     #define BASIC_ENDPOINT              (QBKG11LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG11LM_SWITCH1_ENDPOINT)
     #define ZCL_NUMBER_OF_ENDPOINTS     (2)
@@ -196,5 +206,14 @@
 
 #endif // TARGET_BOARD
 
+
+// Electrical Measurement cluster is registered only on boards with a metering IC
+#ifdef SUPPORTS_POWER_METERING
+#define CLD_ELECTRICAL_MEASUREMENT
+#define ELECTRICAL_MEASUREMENT_SERVER
+#define CLD_ELECTMEAS_ATTR_ACTIVE_POWER
+#define CLD_ELECTMEAS_ATTR_RMS_VOLTAGE
+#define CLD_ELECTMEAS_ATTR_RMS_CURRENT
+#endif
 
 #endif /* ZCL_OPTIONS_H */

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -240,7 +240,10 @@
 #define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
 #define CLD_ELECTMEAS_ATTR_AC_CURRENT_MULTIPLIER
 #define CLD_ELECTMEAS_ATTR_AC_CURRENT_DIVISOR
-// Cumulative energy over the Simple Metering cluster
+// Cumulative energy over the Simple Metering cluster (the SDK inconsistently
+// gates on both names: the cluster source uses CLD_SIMPLE_METERING, the
+// header structs use CLD_SM/SM_SERVER)
+#define CLD_SIMPLE_METERING
 #define CLD_SM
 #define SM_SERVER
 #define CLD_SM_ATTR_MULTIPLIER

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -162,6 +162,14 @@
     #define METERING_CF1_MASK           (1UL << METERING_CF1_PIN)
     #define METERING_SEL_PIN            (9)
     #define METERING_SEL_MASK           (1UL << METERING_SEL_PIN)
+    // Conversion constants, scaled by 1e5: value = freq_dHz * K / 100000.
+    // Power: calibrated 2026-08-02 against an inline power meter (1910 W at
+    // 424.41 Hz CF over a 3 min pulse-count integration) -> 4.5004 W/Hz,
+    // +8.8 % over the datasheet-nominal 4.138 (shunt below its marked 2 mOhm).
+    #define METERING_W_PER_DHZ_E5       (45004)
+    // Voltage: datasheet-nominal (no reference instrument available yet):
+    // 0.32694 V/Hz from Vref 2.43 V, Fosc 3.579 MHz, divider ratio 1881.
+    #define METERING_DV_PER_DHZ_E5      (32694)
 
     #define BASIC_ENDPOINT              (QBKG11LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG11LM_SWITCH1_ENDPOINT)
@@ -219,6 +227,11 @@
 // integrate over minutes instead of trusting one 1 s window
 #define CLD_ELECTMEAS_ATTR_MAN_SPEC_APPARENT_POWER
 #define CLD_ELECTMEAS_ATTR_MAN_SPEC_NON_ACTIVE_POWER
+// Scaling attributes so coordinators can render real units
+#define CLD_ELECTMEAS_ATTR_AC_POWER_MULTIPLIER
+#define CLD_ELECTMEAS_ATTR_AC_POWER_DIVISOR
+#define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_MULTIPLIER
+#define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
 #endif
 
 #endif /* ZCL_OPTIONS_H */

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -167,13 +167,15 @@
     // 424.41 Hz CF over a 3 min pulse-count integration) -> 4.5004 W/Hz,
     // +8.8 % over the datasheet-nominal 4.138 (shunt below its marked 2 mOhm).
     #define METERING_W_PER_DHZ_E5       (45004)
-    // Voltage: datasheet-nominal (no reference instrument available yet):
-    // 0.32694 V/Hz from Vref 2.43 V, Fosc 3.579 MHz, divider ratio 1881.
-    #define METERING_DV_PER_DHZ_E5      (32694)
-    // Current: datasheet-nominal, 7.2423 mA/Hz from Vref and the 2 mOhm shunt.
-    // The power calibration suggests the real shunt is ~9 % low, so expect
-    // this channel to read correspondingly high until calibrated (Phase 3).
-    #define METERING_MA_PER_DHZ_E5      (72423)
+    // Voltage: calibrated 2026-08-02 against a UNI-T UT33D at the load
+    // terminals under load (235.5 V read vs 225.3 V displayed -> +4.53 % over
+    // the datasheet-nominal 0.32694 V/Hz).
+    #define METERING_DV_PER_DHZ_E5      (34176)
+    // Current: derived, not directly measured - all HLW8012 channels share
+    // Vref and the shunt, so Kc = Kp/Kv: 1.0876 / 1.0453 = 1.0405 over the
+    // datasheet-nominal 7.2423 mA/Hz. Cross-check: 8.40 A at 1910 W / 235.5 V
+    // -> PF 0.966, plausible for heater + universal motor.
+    #define METERING_MA_PER_DHZ_E5      (75357)
 
     #define BASIC_ENDPOINT              (QBKG11LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG11LM_SWITCH1_ENDPOINT)

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -240,6 +240,11 @@
 #define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
 #define CLD_ELECTMEAS_ATTR_AC_CURRENT_MULTIPLIER
 #define CLD_ELECTMEAS_ATTR_AC_CURRENT_DIVISOR
+// Cumulative energy over the Simple Metering cluster
+#define CLD_SM
+#define SM_SERVER
+#define CLD_SM_ATTR_MULTIPLIER
+#define CLD_SM_ATTR_DIVISOR
 #endif
 
 #endif /* ZCL_OPTIONS_H */

--- a/src/zcl_options.h
+++ b/src/zcl_options.h
@@ -170,6 +170,10 @@
     // Voltage: datasheet-nominal (no reference instrument available yet):
     // 0.32694 V/Hz from Vref 2.43 V, Fosc 3.579 MHz, divider ratio 1881.
     #define METERING_DV_PER_DHZ_E5      (32694)
+    // Current: datasheet-nominal, 7.2423 mA/Hz from Vref and the 2 mOhm shunt.
+    // The power calibration suggests the real shunt is ~9 % low, so expect
+    // this channel to read correspondingly high until calibrated (Phase 3).
+    #define METERING_MA_PER_DHZ_E5      (72423)
 
     #define BASIC_ENDPOINT              (QBKG11LM_BASIC_ENDPOINT)
     #define SWITCH1_ENDPOINT            (QBKG11LM_SWITCH1_ENDPOINT)
@@ -232,6 +236,8 @@
 #define CLD_ELECTMEAS_ATTR_AC_POWER_DIVISOR
 #define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_MULTIPLIER
 #define CLD_ELECTMEAS_ATTR_AC_VOLTAGE_DIVISOR
+#define CLD_ELECTMEAS_ATTR_AC_CURRENT_MULTIPLIER
+#define CLD_ELECTMEAS_ATTR_AC_CURRENT_DIVISOR
 #endif
 
 #endif /* ZCL_OPTIONS_H */


### PR DESCRIPTION
Draft — implements the "handle current and power sensor" item from the part0 plan. **Fully implemented, calibrated and tested on a QBKG11LM; QBKG12LM testing is pending** (see status below). Opening early for direction feedback.

## What it does

Drives the on-board **HLW8012** energy-metering IC and exposes **active power (W)**, **RMS voltage (V)**, **RMS current (A)** and **cumulative energy (kWh)** over the standard **Electrical Measurement (0x0B04)** and **Simple Metering (0x0702)** clusters on the common endpoint, with working attribute reporting — zigbee2mqtt renders all four natively and values stream without polling. Unlike stock Aqara firmware (which only refreshes power when the relay switches, Koenkk/zigbee2mqtt#1744), this measures and reports continuously.

Full design/calibration documentation is included: `doc/QBKG_HLW8012_power_metering.md` (driver, pitfalls) and `doc/QBKG_HLW8012_power_metering_RE.md` (hardware reverse-engineering — CF→DIO8/PC1, CF1→DIO1/PC0, SEL→DIO9 through an inverting 2N7002).

## Design highlights

- **Acquisition:** the JN5169 hardware pulse counters (defaulting to exactly the right pins) run free; deltas are taken with uint16 wrap-around arithmetic. Sampling windows are measured with a free-running Timer 0 timebase instead of trusting the 1 s ZTIMER tick — the tick jitters under radio load and corrupts both channels by the same factor, which cost me a day of confusing measurements.
- **SEL multiplexing:** voltage/current alternate every 5 windows with the toggle-straddling window discarded; each mode keeps its last valid reading.
- **Calibration:** cumulative pulse counts are exposed in two manufacturer-specific attributes, so a multi-minute count integration against a reference instrument gives multipliers immune to per-window noise. All three channels share Vref and the shunt, so one power reference plus one voltage reference calibrates current too (K_I = K_P/K_V). On my specimen the shunt sits ~9 % under its 2 mΩ marking — constants are per-unit, procedure in the doc.
- **Energy:** each CF pulse is a fixed energy quantum, so the lifetime count is the kWh register; PDM-persisted with a wear-aware policy (every ~0.1 kWh or daily), verified to survive a power cycle.
- **SDK pitfalls found on the way** (documented in the doc): attributes need BOTH `E_ZCL_AF_RP` in the definition table (vendored patched copies of `ElectricalMeasurement.c`/`SimpleMetering.c` — delta is only that flag) and `E_ZCL_ACF_RP` in the instance control bits (`eZCL_SetReportableFlag()`); the reporting engine samples the cluster structs directly, so values are pushed into them every window rather than lazily on read.

## Verification (QBKG11LM)

Power calibrated against an inline power meter and independently cross-checked against a whole-home meter (+1.2 % agreement); voltage against a multimeter at the load terminals under load; current cross-checked via V·I·PF consistency (PF 0.966 for a heater+motor load). Post-calibration the firmware tracked the reference meter within a fraction of a percent at two operating points, including the mains sag under load.

## Status / WIP items

- [ ] **QBKG12LM: metering now enabled** (per review — boards confirmed identical, LM15-LNS-PA-A-T0 + LM16-LNS_MB; the single HLW8012 measures both parallel relay channels combined). Builds green; **runtime testing on a 2-gang unit still pending** — I have one here and will flash it when I find the time.
- Matching zigbee2mqtt converter changes live on my converter branch (`midlan/zigbee-herdsman-converters` @ `add-hellozigbee`): `m.electricityMeter()`, `multiEndpointSkip` for the metering properties, and `write: true` on the custom cluster attributes (newer zigbee-herdsman requires it).
- Heads-up for testing OTA updates with current zigbee2mqtt: zigbee-herdsman sends the OTA upgrade grant with an absolute UTC time, which the JN51xx OTA client compares against its unsynced local clock — the device downloads fine but never reboots into the new image. Fix submitted upstream (Koenkk/zigbee-herdsman#1835); until it ships, power-cycling applies the downloaded image (your `restoreOTAAttributes()` retry-clamp handles it nicely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

