### PR TITLE
Fix BDB primary and secondary channel masks

### DIFF
--- a/src/bdb_options.h
+++ b/src/bdb_options.h
@@ -50,12 +50,12 @@ extern "C" {
 
 /* Channel Definitions */
 #if (SINGLE_CHANNEL < 11 || SINGLE_CHANNEL > 26)
-#define BDB_PRIMARY_CHANNEL_SET                 (0x07fff800)                               /* bdbPrimaryChannelSet */
-#define BDBC_TL_SECONDARY_CHANNEL_SET           (0x07fff800 ^ BDBC_TL_PRIMARY_CHANNEL_SET) /* bdbcTLSecondaryChannelSet */
+#define BDB_PRIMARY_CHANNEL_SET                 (0x02108800)                                /* bdbPrimaryChannelSet */
+#define BDB_SECONDARY_CHANNEL_SET               (0x07FFF800 ^ BDB_PRIMARY_CHANNEL_SET)      /* bdbSecondaryChannelSet */
 #else
 #warning Single channel only!
 #define BDB_PRIMARY_CHANNEL_SET                 (1<<SINGLE_CHANNEL)                        /* bdbPrimaryChannelSet */
-#define BDBC_TL_SECONDARY_CHANNEL_SET           (0)                                        /* bdbcTLSecondaryChannelSet */
+#define BDB_SECONDARY_CHANNEL_SET               (0)                                        /* bdbSecondaryChannelSet */
 #endif
 
 /* BDB Constants used by all nodes


### PR DESCRIPTION
## Summary

- Use the standard BDB primary channel set in multi-channel mode.
- Define `BDB_SECONDARY_CHANNEL_SET` instead of the Touchlink-specific `BDBC_TL_SECONDARY_CHANNEL_SET`.
- Disable secondary channel scanning in single-channel mode.

## Channel sets

In multi-channel mode, Network Steering scans the preferred primary channels first:

- Primary channels: 11, 15, 20, 25
- Secondary channels: 12, 13, 14, 16, 17, 18, 19, 21, 22, 23, 24, 26

In single-channel mode:

- `BDB_PRIMARY_CHANNEL_SET` contains only `SINGLE_CHANNEL`.
- `BDB_SECONDARY_CHANNEL_SET` is zero, preventing fallback scans on other channels.

## Rationale

The existing configuration defines `BDBC_TL_SECONDARY_CHANNEL_SET`. This is a Touchlink-specific constant and does not configure the secondary channel set used by regular BDB Network Steering.

Touchlink is not used by the current configuration: `BDB_COMMISSIONING_MODE` enables only `BDB_COMMISSIONING_MODE_NWK_STEERING`. Therefore, defining `BDBC_TL_SECONDARY_CHANNEL_SET` here is incorrect and has no effect on Network Steering.

Without an explicit `BDB_SECONDARY_CHANNEL_SET`, the SDK supplies its default value. In a single-channel build, this default includes all Zigbee channels except `SINGLE_CHANNEL`, allowing Network Steering to scan other channels despite the single-channel configuration.

This change applies the channel masks to the correct BDB attributes and restores the intended single-channel behavior.
